### PR TITLE
Include Oracle JDK 9 axis to the build matrix on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: java
 
+matrix:
+  include:
+    - jdk: oraclejdk8
+    - jdk: oraclejdk9
+  allow_failures:
+    - jdk: oraclejdk9
+
 install: true


### PR DESCRIPTION
## Overview

Shows exceptions mentioned in #14

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
