### PR TITLE
Refactored DefaultJqwikConfiguration

### DIFF
--- a/src/main/java/net/jqwik/DefaultJqwikConfiguration.java
+++ b/src/main/java/net/jqwik/DefaultJqwikConfiguration.java
@@ -23,17 +23,7 @@ public class DefaultJqwikConfiguration implements JqwikConfiguration {
 
 	@Override
 	public PropertyDefaultValues propertyDefaultValues() {
-		return new PropertyDefaultValues() {
-			@Override
-			public int tries() {
-				return properties.defaultTries();
-			}
-
-			@Override
-			public int maxDiscardRatio() {
-				return properties.defaultMaxDiscardRatio();
-			}
-		};
+		return PropertyDefaultValues.with(properties.defaultTries(), properties.defaultMaxDiscardRatio());
 	}
 
 	@Override

--- a/src/main/java/net/jqwik/DefaultJqwikConfiguration.java
+++ b/src/main/java/net/jqwik/DefaultJqwikConfiguration.java
@@ -57,7 +57,7 @@ public class DefaultJqwikConfiguration implements JqwikConfiguration {
 			public Set<UniqueId> previousFailures() {
 				if (!properties.runFailuresFirst())
 					return Collections.emptySet();
-				return previousRun.allNonSuccessfulTests().map(testRun -> testRun.getUniqueId()).collect(Collectors.toSet());
+				return previousRun.allNonSuccessfulTests().map(TestRun::getUniqueId).collect(Collectors.toSet());
 			}
 		};
 	}


### PR DESCRIPTION
## Overview

I was browsing the code in order to understand the `TestRunDatabase` better.
In `DefaultJqwikConfiguration` I realized that there was some code duplication.
So I applied the boy scout rule and removed the duplication.

Further, there was a lambda expression where a method reference could be used.

### Details

In method `createTestEngineConfiguration` variables `TestRunDatabase` and `TestRunData` could be final. However, other variables in any other method are not final, too. So I decided not to change it.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
