### PR TITLE
Remove TODO about Java 9

### DIFF
--- a/src/main/java/net/jqwik/discovery/JqwikDiscoverer.java
+++ b/src/main/java/net/jqwik/discovery/JqwikDiscoverer.java
@@ -28,7 +28,6 @@ public class JqwikDiscoverer {
 		HierarchicalJavaResolver javaElementsResolver = createHierarchicalResolver(engineDescriptor);
 		Predicate<String> classNamePredicate = buildClassNamePredicate(request);
 
-		// TODO: Test with Java 9 or above
 		request.getSelectorsByType(ModuleSelector.class).forEach(selector -> {
 			findAllClassesInModule(selector.getModuleName(), isScannableTestClass, classNamePredicate)
 				.forEach(javaElementsResolver::resolveClass);


### PR DESCRIPTION
## Overview

Travis builds with Java 8, 9 and 10.
This TODO is not needed anymore.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
