### PR TITLE
Ignore Group annotation on static inner classes

### DIFF
--- a/src/main/java/net/jqwik/discovery/specs/TopLevelContainerDiscoverySpec.java
+++ b/src/main/java/net/jqwik/discovery/specs/TopLevelContainerDiscoverySpec.java
@@ -13,7 +13,7 @@ public class TopLevelContainerDiscoverySpec implements DiscoverySpec<Class<?>> {
 	private final static Predicate<Class<?>> isPotentialTestContainer = new IsPotentialTestContainer();
 	private final static Predicate<Class<?>> isTopLevelClass = new IsTopLevelClass();
 	private final static Predicate<Class<?>> isGroup = candidate -> candidate.isAnnotationPresent(Group.class);
-	private final static Predicate<Class<?>> isStaticNonGroupMember = candidate -> isStatic(candidate) && !isGroup.test(Group.class);
+	private final static Predicate<Class<?>> isStaticNonGroupMember = candidate -> isStatic(candidate) && !isGroup.test(candidate);
 
 	@Override
 	public boolean shouldBeDiscovered(Class<?> candidate) {

--- a/src/test/java/examples/packageWithNestedContainers/ClassWithContainer.java
+++ b/src/test/java/examples/packageWithNestedContainers/ClassWithContainer.java
@@ -1,0 +1,15 @@
+package examples.packageWithNestedContainers;
+
+import net.jqwik.api.Example;
+import net.jqwik.api.Group;
+
+public class ClassWithContainer {
+
+	@Group // should be ignored
+	public static class NestedGroupAnnotatedContainer {
+		@Example
+		void example2() {
+
+		}
+	}
+}

--- a/src/test/java/net/jqwik/discovery/DiscoveryTests.java
+++ b/src/test/java/net/jqwik/discovery/DiscoveryTests.java
@@ -93,6 +93,16 @@ class DiscoveryTests {
 	}
 
 	@Example
+	void discoverNestedContainerAnnotatedWithGroup(){
+		LauncherDiscoveryRequest discoveryRequest = request().selectors(selectClass(ClassWithContainer.NestedGroupAnnotatedContainer.class))
+			.build();
+
+		TestDescriptor engineDescriptor = discoverTests(discoveryRequest);
+		assertThat(engineDescriptor.getDescendants().size()).isEqualTo(2);
+		assertThat(count(engineDescriptor, isClassDescriptor)).isEqualTo(1);
+	}
+
+	@Example
 	void discoverInnerContainerFromClass() {
 		LauncherDiscoveryRequest discoveryRequest = request()
 				.selectors(selectClass(TopLevelContainerWithGroups.InnerGroup.InnerInnerGroup.class)).build();


### PR DESCRIPTION
## Overview
The `TopLevelContainerDiscoverSpec` determines if a class is a container
on top level or not. A class is on top level if it is the top most
public class or if it is a static inner class.

Before this commit, the check for static classes was not done properly.
Instead of checking the candidate, the `Group.class` was checked.

This commit replaces `Group.class` by `candidate` and, thus, the check is
done properly. A test was added with a single nested container annotated
with Group. Within the discovery phase, the group annotation should be
ignored like it is done with other top level containers.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
