### PR TITLE
fix broken links in JavaDoc

### DIFF
--- a/api/src/main/java/net/jqwik/api/configurators/ArbitraryConfiguratorBase.java
+++ b/api/src/main/java/net/jqwik/api/configurators/ArbitraryConfiguratorBase.java
@@ -26,9 +26,9 @@ import static org.junit.platform.commons.support.ReflectionSupport.*;
  * Some examples that come with jqwik:
  *
  * <ul>
- *     <li><a href="https://github.com/jlink/jqwik/blob/master/engine/src/main/java/net/jqwik/engine/configurators/CharsConfigurator.java"
+ *     <li><a href="https://github.com/jlink/jqwik/blob/master/engine/src/main/java/net/jqwik/engine/properties/configurators/CharsConfigurator.java"
  *     >net.jqwik.engine.properties.configurators.CharsConfigurator</a></li>
- *     <li><a href="https://github.com/jlink/jqwik/blob/master/engine/src/main/java/net/jqwik/engine/configurators/SizeConfigurator.java"
+ *     <li><a href="https://github.com/jlink/jqwik/blob/master/engine/src/main/java/net/jqwik/engine/properties/configurators/SizeConfigurator.java"
  *     >net.jqwik.engine.properties.configurators.SizeConfigurator</a></li>
  * </ul>
  */


### PR DESCRIPTION
## Overview

Simple as the title says: Fix some broken links in JavaDoc

### Details

./.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
