### PR TITLE
make whitespace determination dynamic

### DIFF
--- a/api/src/main/java/net/jqwik/api/constraints/Whitespace.java
+++ b/api/src/main/java/net/jqwik/api/constraints/Whitespace.java
@@ -20,34 +20,6 @@ import static org.apiguardian.api.API.Status.*;
  */
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE })
 @Retention(RetentionPolicy.RUNTIME)
-@Chars({
-	'\u0009', //
-	'\n', //
-	'\u000b', //
-	'\u000c', //
-	'\r', //
-	'\u001c', //
-	'\u001d', //
-	'\u001e', //
-	'\u001f', //
-	'\u0020', //
-	'\u1680', //
-	'\u180e', //
-	'\u2000', //
-	'\u2001', //
-	'\u2002', //
-	'\u2003', //
-	'\u2004', //
-	'\u2005', //
-	'\u2006', //
-	'\u2008', //
-	'\u2009', //
-	'\u200a', //
-	'\u2028', //
-	'\u2029', //
-	'\u205f', //
-	'\u3000' //
-})
 @Documented
 @API(status = MAINTAINED, since = "1.0")
 public @interface Whitespace {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitrary.java
@@ -9,6 +9,19 @@ import net.jqwik.engine.properties.arbitraries.exhaustive.*;
 import net.jqwik.engine.properties.arbitraries.randomized.*;
 
 public class DefaultStringArbitrary extends AbstractArbitraryBase implements StringArbitrary {
+	public static final char[] WHITESPACE_CHARS;
+
+	static {
+		// determine WHITESPACE_CHARS at runtime because the environments differ . . .
+		final StringBuilder whitespace = IntStream.range(Character.MIN_VALUE, Character.MAX_VALUE + 1)
+												  .filter(Character::isWhitespace)
+												  .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append);
+
+		final int whitespaceLength = whitespace.length();
+		final char[] charArray = new char[whitespaceLength];
+		whitespace.getChars(0, whitespaceLength, charArray, 0);
+		WHITESPACE_CHARS = charArray;
+	}
 
 	private CharacterArbitrary characterArbitrary = new DefaultCharacterArbitrary();
 
@@ -82,46 +95,9 @@ public class DefaultStringArbitrary extends AbstractArbitraryBase implements Str
 		return clone;
 	}
 
-	/**
-	 * Extracted unicodes from java 8 with
-	 * <pre>
-	 * 	for (char c = Character.MIN_VALUE; c &lt; Character.MAX_VALUE; c++) {
-	 * 		if (Character.isWhitespace(c)) {
-	 * 			System.out.println( "\\u" + Integer.toHexString(c | 0x10000).substring(1) );
-	 * 		}
-	 * 	}
-	 *  </pre>
-	 */
 	@Override
 	public StringArbitrary whitespace() {
-		return this.withChars( //
-			'\u0009', //
-			'\n', //
-			'\u000b', //
-			'\u000c', //
-			'\r', //
-			'\u001c', //
-			'\u001d', //
-			'\u001e', //
-			'\u001f', //
-			'\u0020', //
-			'\u1680', //
-			'\u180e', //
-			'\u2000', //
-			'\u2001', //
-			'\u2002', //
-			'\u2003', //
-			'\u2004', //
-			'\u2005', //
-			'\u2006', //
-			'\u2008', //
-			'\u2009', //
-			'\u200a', //
-			'\u2028', //
-			'\u2029', //
-			'\u205f', //
-			'\u3000' //
-		);
+		return this.withChars(WHITESPACE_CHARS);
 	}
 
 	@Override

--- a/engine/src/main/java/net/jqwik/engine/properties/configurators/WhitespaceConfigurator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/configurators/WhitespaceConfigurator.java
@@ -1,0 +1,25 @@
+package net.jqwik.engine.properties.configurators;
+
+import net.jqwik.api.arbitraries.CharacterArbitrary;
+import net.jqwik.api.arbitraries.StringArbitrary;
+import net.jqwik.api.configurators.ArbitraryConfiguratorBase;
+import net.jqwik.api.constraints.Whitespace;
+import net.jqwik.engine.properties.arbitraries.DefaultStringArbitrary;
+
+public class WhitespaceConfigurator extends ArbitraryConfiguratorBase {
+
+	public StringArbitrary configure(StringArbitrary arbitrary, Whitespace whitespace) {
+		return arbitrary.withChars(DefaultStringArbitrary.WHITESPACE_CHARS);
+	}
+
+	public CharacterArbitrary configure(CharacterArbitrary arbitrary, Whitespace whitespace) {
+		CharacterArbitrary result = arbitrary;
+
+		for (char c : DefaultStringArbitrary.WHITESPACE_CHARS) {
+			result = result.between(c, c);
+		}
+
+		return result;
+	}
+
+}

--- a/engine/src/main/java/net/jqwik/engine/properties/configurators/WhitespaceConfigurator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/configurators/WhitespaceConfigurator.java
@@ -13,13 +13,7 @@ public class WhitespaceConfigurator extends ArbitraryConfiguratorBase {
 	}
 
 	public CharacterArbitrary configure(CharacterArbitrary arbitrary, Whitespace whitespace) {
-		CharacterArbitrary result = arbitrary;
-
-		for (char c : DefaultStringArbitrary.WHITESPACE_CHARS) {
-			result = result.between(c, c);
-		}
-
-		return result;
+		return arbitrary.with(DefaultStringArbitrary.WHITESPACE_CHARS);
 	}
 
 }

--- a/engine/src/main/java/net/jqwik/engine/properties/configurators/WhitespaceConfigurator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/configurators/WhitespaceConfigurator.java
@@ -9,7 +9,7 @@ import net.jqwik.engine.properties.arbitraries.DefaultStringArbitrary;
 public class WhitespaceConfigurator extends ArbitraryConfiguratorBase {
 
 	public StringArbitrary configure(StringArbitrary arbitrary, Whitespace whitespace) {
-		return arbitrary.withChars(DefaultStringArbitrary.WHITESPACE_CHARS);
+		return arbitrary.whitespace();
 	}
 
 	public CharacterArbitrary configure(CharacterArbitrary arbitrary, Whitespace whitespace) {

--- a/engine/src/main/resources/META-INF/services/net.jqwik.api.configurators.ArbitraryConfigurator
+++ b/engine/src/main/resources/META-INF/services/net.jqwik.api.configurators.ArbitraryConfigurator
@@ -4,3 +4,4 @@ net.jqwik.engine.properties.configurators.StringLengthConfigurator
 net.jqwik.engine.properties.configurators.RangeConfigurator
 net.jqwik.engine.properties.configurators.PositiveConfigurator
 net.jqwik.engine.properties.configurators.NegativeConfigurator
+net.jqwik.engine.properties.configurators.WhitespaceConfigurator

--- a/engine/src/test/java/net/jqwik/api/constraints/WhitespaceProperties.java
+++ b/engine/src/test/java/net/jqwik/api/constraints/WhitespaceProperties.java
@@ -1,0 +1,24 @@
+package net.jqwik.api.constraints;
+
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Group;
+import net.jqwik.api.Property;
+
+@Group
+class WhitespaceProperties {
+
+	@Property
+	boolean stringWithWhitespace(@ForAll @Whitespace String aString) {
+		return aString.chars().allMatch(Character::isWhitespace);
+	}
+
+	@Property
+	boolean characterWithWhitespace(@ForAll @Whitespace Character aChar) {
+		return Character.isWhitespace(aChar);
+	}
+
+	@Property
+	boolean charWithWhitespace(@ForAll @Whitespace char aChar) {
+		return Character.isWhitespace(aChar);
+	}
+}

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultCharacterArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultCharacterArbitraryTests.java
@@ -1,6 +1,7 @@
 package net.jqwik.engine.properties.arbitraries;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 import net.jqwik.api.*;
 import net.jqwik.api.arbitraries.*;
@@ -94,4 +95,18 @@ class DefaultCharacterArbitraryTests {
 		);
 	}
 
+	@Example
+	void whitespace() {
+		CharacterArbitrary all = this.arbitrary.with(DefaultStringArbitrary.WHITESPACE_CHARS);
+		assertAllGenerated(all.generator(1000), (Predicate<Character>) Character::isWhitespace);
+		assertAtLeastOneGeneratedOf(all.generator(1000), toCharacterArray(DefaultStringArbitrary.WHITESPACE_CHARS));
+	}
+
+	private Character[] toCharacterArray(char[] chars) {
+		Character[] result = new Character[chars.length];
+		for (int i=0; i<chars.length; i++) {
+			result[i] = chars[i];
+		}
+		return result;
+	}
 }

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitraryTests.java
@@ -128,8 +128,11 @@ class DefaultStringArbitraryTests {
 	@Example
 	void whitespace() {
 		StringArbitrary stringArbitrary = this.arbitrary.whitespace();
-		assertAtLeastOneGenerated(stringArbitrary.generator(10), s -> s.contains(Character.toString(' ')));
-		assertAtLeastOneGenerated(stringArbitrary.generator(10), s -> s.contains(Character.toString('\t')));
+
+		// the loop _could_ be extracted to an overloaded version of "assertAtLeastOneGeneratedOf" . . .
+		for (char c : DefaultStringArbitrary.WHITESPACE_CHARS) {
+			assertAtLeastOneGenerated(stringArbitrary.generator(10), s -> s.contains(Character.toString(c)));
+		}
 	}
 
 }


### PR DESCRIPTION
## Overview

Like described in [issue #55](https://github.com/jlink/jqwik/issues/55), using the Java 8 fixed set of whitespace characters leads to wrong results in a Java 11 environment.  

This change aims to determine the set of whitespace characters at runtime, thus avoiding problems caused by changes between Java versions.


---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).