### PR TITLE
Replace `@Digits` with `@NumericChars`

### DIFF
--- a/docs/docs/current/user-guide.md
+++ b/docs/docs/current/user-guide.md
@@ -824,7 +824,7 @@ The following example provides an annotation to constrain String or Character ge
 ```java
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
-@Digits
+@NumericChars
 @AlphaChars
 @Chars({'ä', 'ö', 'ü', 'Ä', 'Ö', 'Ü', 'ß'})
 @Chars({' ', '.', ',', ';', '?', '!'})


### PR DESCRIPTION
## Overview

Couldn't find a changelog, but it looks like `@Digits` has been replaced by `@NumericChars` at some point?

### Details

n/a

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).