### PR TITLE
Replace `@Digits` with `@NumericChars`

### DIFF
--- a/documentation/src/docs/user-guide.template.md
+++ b/documentation/src/docs/user-guide.template.md
@@ -734,7 +734,7 @@ The following example provides an annotation to constrain String or Character ge
 ```java
 @Target({ ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
 @Retention(RetentionPolicy.RUNTIME)
-@Digits
+@NumericChars
 @AlphaChars
 @Chars({'ä', 'ö', 'ü', 'Ä', 'Ö', 'Ü', 'ß'})
 @Chars({' ', '.', ',', ';', '?', '!'})


### PR DESCRIPTION
## Overview

Replace `@Digits` with `@NumericChars`, which has been deprecated in v0.8.4 and removed in v0.9.0.

Fixup for #60.

### Details

n/a

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
