### PR TITLE
allow non-static `DomainContext`s to be defined in base classes

### DIFF
--- a/engine/src/test/java/net/jqwik/api/BaseDomainContexts.java
+++ b/engine/src/test/java/net/jqwik/api/BaseDomainContexts.java
@@ -1,0 +1,15 @@
+package net.jqwik.api;
+
+import net.jqwik.api.domains.AbstractDomainContextBase;
+
+abstract class BaseDomainContexts {
+
+	Integer[] specificNumbers;
+
+	class SpecificNumbersContext extends AbstractDomainContextBase {
+		private SpecificNumbersContext() {
+			registerArbitrary(Integer.class, Arbitraries.of(specificNumbers));
+		}
+	}
+
+}

--- a/engine/src/test/java/net/jqwik/api/DomainContextTests.java
+++ b/engine/src/test/java/net/jqwik/api/DomainContextTests.java
@@ -8,7 +8,11 @@ import net.jqwik.api.domains.*;
 
 import static org.assertj.core.api.Assertions.*;
 
-class DomainContextTests {
+class DomainContextTests extends BaseDomainContexts {
+
+	DomainContextTests() {
+		specificNumbers = new Integer[]{10, 11, 12};
+	}
 
 	@Property(tries = 20)
 	@Domain(NumberStringContext.class)
@@ -57,6 +61,14 @@ class DomainContextTests {
 		@ForAll int aNumber
 	) {
 		assertThat(aNumber).isBetween(1000000, 9000000);
+	}
+
+	@Property
+	@Domain(SpecificNumbersContext.class)
+	void contextFromSuperClass(
+		@ForAll int aNumber
+	) {
+		assertThat(aNumber).isBetween(10, 12);
 	}
 
 	@Target({ElementType.PARAMETER})

--- a/engine/src/test/java/net/jqwik/engine/support/JqwikReflectionSupportTests.java
+++ b/engine/src/test/java/net/jqwik/engine/support/JqwikReflectionSupportTests.java
@@ -39,6 +39,32 @@ class JqwikReflectionSupportTests {
 	}
 
 	@Group
+	class NewInstanceInTestContext {
+
+		@Example
+		boolean staticInnerClass() {
+			return JqwikReflectionSupport.newInstanceInTestContext(Outer.class, null) instanceof Outer;
+		}
+
+		@Example
+		boolean toplevelClass() {
+			return JqwikReflectionSupport.newInstanceInTestContext(JqwikReflectionSupportTests.class, null) instanceof JqwikReflectionSupportTests;
+		}
+
+		@Example
+		boolean innerClass() {
+			return JqwikReflectionSupport.newInstanceInTestContext(Outer.InnerWithConstructor.class, new Outer()) instanceof Outer.InnerWithConstructor;
+		}
+
+		@Example
+		boolean innerClassInherited() {
+			return JqwikReflectionSupport.newInstanceInTestContext(OuterBase.Inner.class, new OuterSub()) instanceof OuterBase.Inner;
+
+		}
+
+	}
+
+	@Group
 	class GetMethodParameters {
 
 		@Example
@@ -150,6 +176,26 @@ class JqwikReflectionSupportTests {
 				this.aString = "hallo";
 			}
 		}
+	}
+
+	private static abstract class OuterBase {
+
+		public OuterBase(int i) {
+
+		}
+
+		class Inner {
+
+		}
+
+	}
+
+	private static class OuterSub extends OuterBase {
+
+		public OuterSub() {
+			super(0);
+		}
+
 	}
 
 	private static class OuterWithConstructor {


### PR DESCRIPTION
## Overview

When using the `@Domain` annotation with inner classes, instantiation only works on `static` inner classes or non-`static` inner classes in the same class. There is no technical reason why non-`static` inner classes inherited from a superclass shouldn't work.

### Details

I changed a `Class<?>` _equality_ check to an `isAssignableFrom` check.

Also, we already spent time figuring out the `outerClass` ourselves, so we can also compute the `Constructor<?>` ourselves. This is necessary for the following reason:

– Previously, the code called `ReflectionSupport.newInstance(clazz, parentInstance)` from JUnit.
– JUnit will look at the class of `parentInstance` and will try to figure out the correct constructor in `clazz`.
– However, if `parentInstance` is a subclass of `outerClass` (which this PR enables), then there is no appropriate constructor.
– Consequently, we need to select the constructor "statically" from the `clazz`.

(I've tried this out, and without that second change, my test case fails).

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
