### PR TITLE
Fix Unshrinkable null value equals And hashCode error

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/Unshrinkable.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/Unshrinkable.java
@@ -3,6 +3,8 @@ package net.jqwik.engine.properties.shrinking;
 import net.jqwik.api.*;
 import net.jqwik.engine.support.*;
 
+import java.util.Objects;
+
 public class Unshrinkable<T> implements Shrinkable<T> {
 	private final T value;
 
@@ -35,11 +37,11 @@ public class Unshrinkable<T> implements Shrinkable<T> {
 
 		Unshrinkable<?> that = (Unshrinkable<?>) o;
 
-		return value.equals(that.value);
+		return Objects.equals(value, that.value);
 	}
 
 	@Override
 	public int hashCode() {
-		return value.hashCode();
+		return Objects.hashCode(value);
 	}
 }

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/UnshrinkableTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/UnshrinkableTests.java
@@ -1,0 +1,31 @@
+package net.jqwik.engine.properties.shrinking;
+
+import net.jqwik.api.*;
+import net.jqwik.api.arbitraries.SizableArbitrary;
+import org.assertj.core.api.Assertions;
+
+import java.util.Random;
+import java.util.Set;
+
+class UnshrinkableTests {
+	@Example
+	void nullValueEquals() {
+		Unshrinkable<?> unshrinkable1 = new Unshrinkable<>(null);
+		Unshrinkable<?> unshrinkable2 = new Unshrinkable<>(null);
+		Assertions.assertThat(unshrinkable1.equals(unshrinkable2)).isTrue();
+	}
+
+	@Example
+	void nullValueHashCode() {
+		Unshrinkable<?> unshrinkable = new Unshrinkable<>(null);
+		Assertions.assertThat(unshrinkable.hashCode()).isEqualTo(0);
+	}
+
+	@Property(tries = 50)
+	void nullValueUnshrinkable(@ForAll Random random) {
+		SizableArbitrary<Set<String>> setArbitrary = Arbitraries.strings().injectNull(1.0).set().ofSize(1);	// Element Unshrinkable null value
+		Set<?> set = setArbitrary.generator(10).next(random).value();
+		Assertions.assertThat(set).isNotEmpty();
+		Assertions.assertThat(set.iterator().next()).isNull();
+	}
+}


### PR DESCRIPTION
## Overview

- Unshrinkable null value got exception when call equals or hashCode method

### Details

- Fix equals and hashCode method to escape NPE.

---

I hereby agree to the terms of the jqwik Contributor Agreement.