### PR TITLE
fix wrong link

### DIFF
--- a/docs/docs/1.1.0/user-guide.md
+++ b/docs/docs/1.1.0/user-guide.md
@@ -2385,7 +2385,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.1.0/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.1.0/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.1.0/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.1.1/user-guide.md
+++ b/docs/docs/1.1.1/user-guide.md
@@ -2445,7 +2445,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.1.1/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.1.1/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.1.1/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.1.2/user-guide.md
+++ b/docs/docs/1.1.2/user-guide.md
@@ -2473,7 +2473,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.1.2/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.1.2/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.1.2/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.1.3/user-guide.md
+++ b/docs/docs/1.1.3/user-guide.md
@@ -2473,7 +2473,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.1.3/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.1.3/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.1.3/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.1.4/user-guide.md
+++ b/docs/docs/1.1.4/user-guide.md
@@ -2522,7 +2522,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.1.4/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.1.4/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.1.4/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.1.5/user-guide.md
+++ b/docs/docs/1.1.5/user-guide.md
@@ -2521,7 +2521,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.1.5/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.1.5/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.1.5/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.1.6/user-guide.md
+++ b/docs/docs/1.1.6/user-guide.md
@@ -2529,7 +2529,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.1.6/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.1.6/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.1.6/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.2.0/user-guide.md
+++ b/docs/docs/1.2.0/user-guide.md
@@ -2679,7 +2679,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.2.0/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.2.0/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.2.0/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/1.2.1/user-guide.md
+++ b/docs/docs/1.2.1/user-guide.md
@@ -2681,7 +2681,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.2.1/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.2.1/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.2.1/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/current/user-guide.md
+++ b/docs/docs/current/user-guide.md
@@ -2681,7 +2681,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/1.2.1/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/1.2.1/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/1.2.1/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/docs/docs/snapshot/user-guide.md
+++ b/docs/docs/snapshot/user-guide.md
@@ -2664,7 +2664,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/master/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/master/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/snapshot/javadoc/net/jqwik/api/constraints/UseType.html)

--- a/documentation/src/docs/user-guide.template.md
+++ b/documentation/src/docs/user-guide.template.md
@@ -2585,7 +2585,7 @@ the class in order to generate instances. Whenever there's an exception during
 generation they will be ignored; that way you'll only get valid instances.
 
 There are quite a few ways usage and configuration options. Have a look
-at the [complete example](https://github.com/jlink/jqwik/blob/${gitVersion}/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java)
+at the [complete example](https://github.com/jlink/jqwik/blob/${gitVersion}/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java)
 and check the following api entry points:
 
 - [UseType](/docs/${docsVersion}/javadoc/net/jqwik/api/constraints/UseType.html)


### PR DESCRIPTION
Link for example was not correct. Now it points to https://github.com/jlink/jqwik/blob/1.1.2/documentation/src/test/java/net/jqwik/docs/types/TypeArbitraryExamples.java instead of https://github.com/jlink/jqwik/blob/1.2.1/documentation/src/test/java/net/jqwik/docs/types/PersonProperties.java .

## Overview

_Formulate the problem / feature your pull request is aiming at_

### Details

_Give any necessary details about your code that is not obvious from the code itself._

_List open issues and remaining problems with your solution._

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
