### PR TITLE
Make StatisticsCollector.collect return this reference

### DIFF
--- a/api/src/main/java/net/jqwik/api/statistics/StatisticsCollector.java
+++ b/api/src/main/java/net/jqwik/api/statistics/StatisticsCollector.java
@@ -28,7 +28,7 @@ public interface StatisticsCollector {
 	 *               </ul>
 	 * @throws IllegalArgumentException if one of the constraints on {@code values} is violated
 	 */
-	void collect(Object... values);
+	StatisticsCollector collect(Object... values);
 
 	/**
 	 * Perform coverage checking for successful property on statistics.

--- a/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsCollectorImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsCollectorImpl.java
@@ -28,11 +28,12 @@ public class StatisticsCollectorImpl implements StatisticsCollector {
 	}
 
 	@Override
-	public void collect(Object... values) {
+	public StatisticsCollector collect(Object... values) {
 		ensureAtLeastOneParameter(values);
 		List<Object> key = keyFrom(values);
 		ensureSameNumberOfValues(key);
 		updateCounts(key);
+		return this;
 	}
 
 	private void updateCounts(List<Object> key) {


### PR DESCRIPTION
## Overview

Addressing another "issue" from https://github.com/jlink/jqwik/issues/75

Making possible:
```java
        Statistics.label("passwdLength").collect(pwdLen).coverage(checker -> {
            checker.check("zero").count(x -> x > 10);
            checker.check("9..13").count(x -> x > 10);
            checker.check("more than 13").count(x -> x > 10);
        });
```

### Details

Note, that behavior of this code is somewhat questionable:
```java
        Statistics.label("labelFizz").collect(3L).coverageOf("buzz", checker -> {
            checker.check(5L).count(x -> x > 10);
        });
```
Should it be "fixed" by prohibiting making `coverageOf` unavailable in "LabeledStatisticsCollector"?

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
