### PR TITLE
docs : Add other JunitEngines for Gradle

### DIFF
--- a/documentation/src/docs/user-guide.template.md
+++ b/documentation/src/docs/user-guide.template.md
@@ -53,7 +53,10 @@ ext.jqwikVersion = '${version}'
 
 test {
 	useJUnitPlatform {
-		includeEngines "jqwik"
+		includeEngines("jqwik")
+        
+        // Or other Junit engines if you use them
+        // includeEngines("jqwik", "junit-jupiter", "junit-vintage")
 
 		// includeTags "fast", "medium"
 		// excludeTags "slow"


### PR DESCRIPTION
## Overview

Add `junit-jupiter` and `junit-vintage` in Gradle documentation.

### Details

This will prevent to disable standard Junit engines when integrating jqwik in project with Junit 5/4 tests.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
