### PR TITLE
Link to directly to Maven Central

### DIFF
--- a/documentation/src/docs/user-guide.template.md
+++ b/documentation/src/docs/user-guide.template.md
@@ -23,7 +23,7 @@ That means that you can use it either stand-alone or combine it with any other J
 All you have to do is add all needed engines to your `testCompile` dependencies as shown in the
 [gradle file](#gradle) below.
 
-The latest release of __jqwik__ is deployed to [Maven Central](https://mvnrepository.com/).
+The latest release of __jqwik__ is deployed to [Maven Central](https://search.maven.org/search?q=g:net.jqwik).
 
 Snapshot releases can be fetched from https://oss.sonatype.org/content/repositories/snapshots.
 


### PR DESCRIPTION
Prior to this commit, the link referenced the landing page of a third-party/meta-crawler website. Now, the official search page is leveraged: https://search.maven.org/search?q=g:net.jqwik

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
