### PR TITLE
Add javadoc documentation to some annotations

### DIFF
--- a/api/src/main/java/net/jqwik/api/Property.java
+++ b/api/src/main/java/net/jqwik/api/Property.java
@@ -8,15 +8,18 @@ import org.junit.platform.commons.annotation.*;
 import static org.apiguardian.api.API.Status.*;
 
 /**
- * Use {@code @Property} to mark methods that serve as properties.
- * Those methods usually have or more parameters annotated with {@linkplain ForAll}.
- *
+ * Use {@code @Property} to mark methods that serve as properties.
+ * Those methods usually have one or more parameters annotated with {@linkplain ForAll}.
+ * <p>
  * They are executed (tried) several times,
- * either until they fail or until the configured number of {@code tries()} has been reached.
- *
+ * either until they fail or until the configured number of {@code tries()} has been reached.
+ * <p>
  * Just like methods annotated with {@linkplain Example} example, annotated methods
  * must not be private. They can either return {@code Boolean}, {@code boolean}
  * or {@code void}.
+ * <p>
+ * For more info, you can have a look at user guide,
+ * <a href="https://jqwik.net/docs/current/user-guide.html#optional-property-parameters">optional-property-parameters</a>.
  *
  * @see Example
  * @see ShrinkingMode
@@ -24,7 +27,7 @@ import static org.apiguardian.api.API.Status.*;
  * @see AfterFailureMode
  * @see Data
  */
-@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Testable
@@ -35,12 +38,28 @@ public @interface Property {
 	String SEED_NOT_SET = "";
 	String DEFAULT_STEREOTYPE = "Property";
 
+	/**
+	 * Number of tries (test runs with different parameters). By default it is 1000. You can override globally in the property file
+	 * (see <a href="https://jqwik.net/docs/current/user-guide.html#jqwik-configuration">jqwik.properties</a>, or here, in {@link Property}
+	 * annotation.
+	 */
 	int tries() default TRIES_NOT_SET;
 
+	/**
+	 * The maximal number of tried versus actually checked property runs in case you are using Assumptions. If the ratio is exceeded jqwik
+	 * will report this property as a failure.
+	 * <p>
+	 * The default is 5 which can be overridden in <a href="https://jqwik.net/docs/current/user-guide.html#jqwik-configuration">jqwik.properties</a>.
+	 */
 	int maxDiscardRatio() default MAX_DISCARD_RATIO_NOT_SET;
 
 	String seed() default SEED_NOT_SET;
 
+	/**
+	 * Controls how shrinking is done when falsified property is found.
+	 * <p>
+	 * Default value is {@link ShrinkingMode#BOUNDED}, i.e. shrinking is tried to a depth of 1000 steps maximum per value.
+	 */
 	ShrinkingMode shrinking() default ShrinkingMode.BOUNDED;
 
 	String stereotype() default DEFAULT_STEREOTYPE;

--- a/api/src/main/java/net/jqwik/api/Reporting.java
+++ b/api/src/main/java/net/jqwik/api/Reporting.java
@@ -8,7 +8,17 @@ import static org.apiguardian.api.API.Status.*;
 
 @API(status = MAINTAINED, since = "1.0")
 public enum Reporting {
-	GENERATED, FALSIFIED;
+	/**
+	 * {@link Reporting#GENERATED} will report each generated set of the parameters.
+	 * This means that after each property test, summary table will be printed.
+	 */
+	GENERATED,
+
+	/**
+	 * {@link Reporting#FALSIFIED} will report each set of parameters that is falsified during shrinking.
+	 * i.e., report "table" will be printed only when some test fails.
+	 */
+	FALSIFIED;
 
 	public boolean containedIn(Reporting[] reporting) {
 		return Arrays.stream(reporting).anyMatch(this::equals);

--- a/api/src/main/java/net/jqwik/api/ShrinkingMode.java
+++ b/api/src/main/java/net/jqwik/api/ShrinkingMode.java
@@ -5,8 +5,8 @@ import org.apiguardian.api.*;
 import static org.apiguardian.api.API.Status.*;
 
 /**
- * The shrinking mode defines the shrinking behaviour of a property.
- * It can be set in {@linkplain Property#shrinking()} for any property method; default is {@linkplain #BOUNDED}.
+ * The shrinking mode defines the shrinking behaviour of a property.
+ * It can be set in {@linkplain Property#shrinking()} for any property method; default is {@linkplain #BOUNDED}.
  *
  * @see Property
  *


### PR DESCRIPTION
## Overview

When coding, sometimes definition for annotation come handy. They are mostly missing.

### Details

Added some javadoc. Some copied from user guide, some authored myself.

Some nonbreakable spaces inserted also.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
