### PR TITLE
initilize constants thread safe

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/LazyServiceLoaderCache.java
+++ b/engine/src/main/java/net/jqwik/engine/LazyServiceLoaderCache.java
@@ -1,0 +1,26 @@
+package net.jqwik.engine;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class LazyServiceLoaderCache<S> {
+	private final Class<S> clz;
+	private List<S> services;
+
+	public LazyServiceLoaderCache(Class<S> clz) {
+		this.clz = clz;
+	}
+
+	public List<S> getServices() {
+		if (services == null) {
+			loadServices();
+		}
+		return services;
+	}
+
+	private synchronized void loadServices() {
+		services = new CopyOnWriteArrayList<>();
+		ServiceLoader.load(clz).forEach(services::add);
+	}
+}

--- a/engine/src/main/java/net/jqwik/engine/execution/lifecycle/RegisteredLifecycleHooks.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/lifecycle/RegisteredLifecycleHooks.java
@@ -1,21 +1,12 @@
 package net.jqwik.engine.execution.lifecycle;
 
-import java.util.*;
-
 import net.jqwik.api.lifecycle.*;
+import net.jqwik.engine.LazyServiceLoaderCache;
 
 public class RegisteredLifecycleHooks {
+	private static final LazyServiceLoaderCache<LifecycleHook> serviceCache = new LazyServiceLoaderCache(LifecycleHook.class);
 
-	private static List<LifecycleHook> registeredHooks = null;
-
-	public static synchronized Iterable<LifecycleHook> getRegisteredHooks() {
-		if (registeredHooks == null) {
-			registeredHooks = new ArrayList<>();
-			for (LifecycleHook lifecycleHook : ServiceLoader.load(LifecycleHook.class)) {
-				registeredHooks.add(lifecycleHook);
-			}
-		}
-		return registeredHooks;
+	public static Iterable<LifecycleHook> getRegisteredHooks() {
+		return serviceCache.getServices();
 	}
-
 }

--- a/engine/src/main/java/net/jqwik/engine/execution/reporting/RegisteredSampleReportingFormats.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/reporting/RegisteredSampleReportingFormats.java
@@ -3,30 +3,20 @@ package net.jqwik.engine.execution.reporting;
 import java.util.*;
 
 import net.jqwik.api.*;
+import net.jqwik.engine.LazyServiceLoaderCache;
 
 public class RegisteredSampleReportingFormats {
 
-	private static List<SampleReportingFormat> registeredFormats;
+	private static final LazyServiceLoaderCache<SampleReportingFormat> serviceCache = new LazyServiceLoaderCache(SampleReportingFormat.class);
 
 	public static List<SampleReportingFormat> getReportingFormats() {
-		if (null == registeredFormats) {
-			loadSampleReportingFormats();
-		}
-		return Collections.unmodifiableList(new ArrayList<>(registeredFormats));
-	}
-
-	private static void loadSampleReportingFormats() {
-		registeredFormats = new ArrayList<>();
-		Iterable<SampleReportingFormat> providers = ServiceLoader.load(SampleReportingFormat.class);
-		for (SampleReportingFormat provider : providers) {
-			register(provider);
-		}
+		return Collections.unmodifiableList(new ArrayList<>(serviceCache.getServices()));
 	}
 
 	public static void register(SampleReportingFormat reportingFormat) {
-		if (getReportingFormats().contains(reportingFormat)) {
+		if (serviceCache.getServices().contains(reportingFormat)) {
 			return;
 		}
-		registeredFormats.add(0, reportingFormat);
+		serviceCache.getServices().add(0, reportingFormat);
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/properties/configurators/RegisteredArbitraryConfigurators.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/configurators/RegisteredArbitraryConfigurators.java
@@ -3,32 +3,20 @@ package net.jqwik.engine.properties.configurators;
 import java.util.*;
 
 import net.jqwik.api.configurators.*;
+import net.jqwik.engine.LazyServiceLoaderCache;
 
 public class RegisteredArbitraryConfigurators {
 
-	private static List<ArbitraryConfigurator> registeredConfigurators;
+	private static final LazyServiceLoaderCache<ArbitraryConfigurator> serviceCache = new LazyServiceLoaderCache(ArbitraryConfigurator.class);
 
 	public static List<ArbitraryConfigurator> getConfigurators() {
-		if (null == registeredConfigurators) {
-			loadArbitraryConfigurators();
-		}
-		return Collections.unmodifiableList(registeredConfigurators);
-	}
-
-	private static void loadArbitraryConfigurators() {
-		registeredConfigurators = new ArrayList<>();
-		Iterable<ArbitraryConfigurator> providers = ServiceLoader.load(ArbitraryConfigurator.class);
-		for (ArbitraryConfigurator provider : providers) {
-			register(provider);
-		}
-		Collections.sort(registeredConfigurators);
+		return Collections.unmodifiableList(serviceCache.getServices());
 	}
 
 	public static void register(ArbitraryConfigurator configurator) {
-		if (getConfigurators().contains(configurator)) {
+		if (serviceCache.getServices().contains(configurator)) {
 			return;
 		}
-		registeredConfigurators.add(0, configurator);
+		serviceCache.getServices().add(0, configurator);
 	}
-
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/RegisteredArbitraryProviders.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/RegisteredArbitraryProviders.java
@@ -3,43 +3,34 @@ package net.jqwik.engine.providers;
 import java.util.*;
 
 import net.jqwik.api.providers.*;
+import net.jqwik.engine.LazyServiceLoaderCache;
 
 public class RegisteredArbitraryProviders {
 
-	private static List<ArbitraryProvider> registeredProviders;
+	private static final LazyServiceLoaderCache<ArbitraryProvider> serviceCache = new LazyServiceLoaderCache(ArbitraryProvider.class);
 
 	public static List<ArbitraryProvider> getProviders() {
-		if (null == registeredProviders) {
-			loadArbitraryProviders();
-		}
-		return Collections.unmodifiableList(new ArrayList<>(registeredProviders));
-	}
-
-	private static void loadArbitraryProviders() {
-		registeredProviders = new ArrayList<>();
-		Iterable<ArbitraryProvider> providers = ServiceLoader.load(ArbitraryProvider.class);
-		for (ArbitraryProvider provider : providers) {
-			register(provider);
-		}
+		return Collections.unmodifiableList(new ArrayList<>(serviceCache.getServices()));
 	}
 
 	public static void register(ArbitraryProvider provider) {
-		if (getProviders().contains(provider)) {
+		if (serviceCache.getServices().contains(provider)) {
 			return;
 		}
-		registeredProviders.add(0, provider);
+		serviceCache.getServices().add(0, provider);
 	}
 
 	public static void unregister(ArbitraryProvider providerToDelete) {
-		getProviders().stream() //
-				.filter(provider -> provider == providerToDelete) //
-				.forEach(provider -> registeredProviders.remove(provider));
+		List<ArbitraryProvider> services = serviceCache.getServices();
+		services.stream()
+			.filter(provider -> provider == providerToDelete)
+			.forEach(services::remove);
 	}
 
 	public static void unregister(Class<? extends ArbitraryProvider> providerClass) {
-		getProviders().stream() //
-				.filter(provider -> provider.getClass() == providerClass) //
-				.forEach(provider -> registeredProviders.remove(provider));
+		List<ArbitraryProvider> services = serviceCache.getServices();
+		services.stream()
+			.filter(provider -> provider.getClass() == providerClass)
+			.forEach(services::remove);
 	}
-
 }


### PR DESCRIPTION
## Overview

I want to use Jqwik Arbitraries in normal JUnit test to generate some example data. I get errors when I run those test in parallel, because Jqwik does not initialize constants (e.g. Provider) in a thread safe way.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
