### PR TITLE
Fix generate single sample with null value

### DIFF
--- a/api/src/main/java/net/jqwik/api/Arbitrary.java
+++ b/api/src/main/java/net/jqwik/api/Arbitrary.java
@@ -441,8 +441,10 @@ public interface Arbitrary<T> {
 	@API(status = MAINTAINED, since = "1.3.0")
 	default T sample() {
 		return this.sampleStream()
-				   .findFirst()
-				   .orElseThrow(() -> new JqwikException("Cannot generate a value"));
+			.map(Optional::ofNullable)
+			.findFirst()
+			.orElseThrow(() -> new JqwikException("Cannot generate a value"))
+			.orElse(null);
 	}
 
 	/**

--- a/documentation/src/test/java/net/jqwik/docs/SamplingExamples.java
+++ b/documentation/src/test/java/net/jqwik/docs/SamplingExamples.java
@@ -11,9 +11,9 @@ class SamplingExamples {
 
 	@Example
 	void generateSingleSample() {
-		Arbitrary<String> strings = Arbitraries.of("string1", "string2", "string3");
+		Arbitrary<String> strings = Arbitraries.of("string1", "string2", "string3", null);
 		String aString = strings.sample();
-		assertThat(aString).isIn("string1", "string2", "string3");
+		assertThat(aString).isIn("string1", "string2", "string3", null);
 	}
 
 	@Example


### PR DESCRIPTION
## Overview

`Arbitrary.sample` throws NullPointException when generating null values.
Calling the `findFirst` method on Stream does not allow null values.

### Details

To avoid handling null values, wrap it with Optional and handle it.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).