### PR TITLE
Fix heading of the Arbitrary.tupleN method listing

### DIFF
--- a/documentation/src/docs/user-guide.template.md
+++ b/documentation/src/docs/user-guide.template.md
@@ -1450,7 +1450,7 @@ If you want to generate tuples of the same base types that also use the same gen
 Arbitrary<Tuple.Tuple2> integerPair = Arbitrary.integers().between(1, 25).tuple2();
 ```
 
-There's a method for tuples of length 1 to 4:
+There's a method for tuples of length 1 to 5:
 
 - [`Arbitrary.tuple1()`](/docs/${docsVersion}/javadoc/net/jqwik/api/Arbitrary.html#tuple1())
 - [`Arbitrary.tuple2()`](/docs/${docsVersion}/javadoc/net/jqwik/api/Arbitrary.html#tuple2())


### PR DESCRIPTION
## Overview

I read the use guide again and noticed this does not match, as far as I can see, support for longer tuples was implemented and only the listing entry got added. This PR updates the heading of the method listing.

### Details

Looking closer at the available Tuples and methods, I don't know if it is a design decision to limit the methods in Arbitrary to tuples of length five when they go up to length eight. I guess it is, as those are rarely needed as product of an `Arbitrary` and all above length four were added together (f3a1dbfe1541f463c6fa00f1cf1f3ef4a79043ed) and five alone (9369182ac76a3144bbe37b4b3813615437c590b3), but I thought I might just mention it as well.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
