### PR TITLE
add ability to warn or fail a test if a seed is fixed

### DIFF
--- a/api/src/main/java/net/jqwik/api/FixedSeedMode.java
+++ b/api/src/main/java/net/jqwik/api/FixedSeedMode.java
@@ -1,0 +1,28 @@
+package net.jqwik.api;
+
+import org.apiguardian.api.*;
+
+import static org.apiguardian.api.API.Status.*;
+
+/**
+ * The fixed seed mode determines how jqwik should behave if a property has an
+ * explicit {@link Property#seed()} specified. It can be set in
+ * {@linkplain Property#whenFixedSeed()} for any property method. It can be set
+ * globally using the property {@code jqwik.seeds.whenfixed}.
+ * <p>
+ * This may be useful, for instance, to help prevent a build server from using
+ * a fixed seed that may have been accidentally committed.
+ * <p>
+ * If it is not set explicitly mode {@linkplain #ALLOW} will be used.
+ *
+ * @see Property
+ */
+@API(status = EXPERIMENTAL, since = "1.4.0")
+public enum FixedSeedMode {
+	ALLOW,
+	WARN,
+	FAIL,
+
+	@API(status = INTERNAL)
+	NOT_SET;
+}

--- a/api/src/main/java/net/jqwik/api/Property.java
+++ b/api/src/main/java/net/jqwik/api/Property.java
@@ -81,4 +81,15 @@ public @interface Property {
 
 	@API(status = EXPERIMENTAL, since = "1.3.0")
 	EdgeCasesMode edgeCases() default EdgeCasesMode.NOT_SET;
+
+	/**
+	 * Controls how to behave if a {@link #seed()} is present.
+	 * <p>
+	 * Default value is the value from the global {@code jqwik.seeds.whenfixed}
+	 * configuration property.
+	 *
+	 * @return the fixed seed mode
+	 */
+	@API(status = EXPERIMENTAL, since = "1.4.0")
+	FixedSeedMode whenFixedSeed() default FixedSeedMode.NOT_SET;
 }

--- a/api/src/main/java/net/jqwik/api/PropertyDefaults.java
+++ b/api/src/main/java/net/jqwik/api/PropertyDefaults.java
@@ -30,6 +30,7 @@ public @interface PropertyDefaults {
 
 	EdgeCasesMode edgeCases() default EdgeCasesMode.NOT_SET;
 
+	@API(status = EXPERIMENTAL, since = "1.4.0")
 	FixedSeedMode whenFixedSeed() default FixedSeedMode.NOT_SET;
 
 	class PropertyDefaultsHook implements AroundPropertyHook {

--- a/api/src/main/java/net/jqwik/api/PropertyDefaults.java
+++ b/api/src/main/java/net/jqwik/api/PropertyDefaults.java
@@ -30,6 +30,8 @@ public @interface PropertyDefaults {
 
 	EdgeCasesMode edgeCases() default EdgeCasesMode.NOT_SET;
 
+	FixedSeedMode whenFixedSeed() default FixedSeedMode.NOT_SET;
+
 	class PropertyDefaultsHook implements AroundPropertyHook {
 
 		@Override
@@ -64,6 +66,12 @@ public @interface PropertyDefaults {
 				PropertyAttributes attributes = context.attributes();
 				if (!attributes.edgeCases().isPresent()) {
 					attributes.setEdgeCases(edgeCases);
+				}
+			});
+			findFixedSeedMode(propertyDefaults).ifPresent(mode -> {
+				PropertyAttributes attributes = context.attributes();
+				if (!attributes.whenFixedSeed().isPresent()) {
+					attributes.setWhenFixedSeed(mode);
 				}
 			});
 
@@ -102,6 +110,13 @@ public @interface PropertyDefaults {
 			return propertyDefaults.stream()
 								   .map(PropertyDefaults::edgeCases)
 								   .filter(edgeCases -> edgeCases != EdgeCasesMode.NOT_SET)
+								   .findFirst();
+		}
+
+		private Optional<FixedSeedMode> findFixedSeedMode(List<PropertyDefaults> propertyDefaults) {
+			return propertyDefaults.stream()
+								   .map(PropertyDefaults::whenFixedSeed)
+								   .filter(mode -> mode != FixedSeedMode.NOT_SET)
 								   .findFirst();
 		}
 

--- a/api/src/main/java/net/jqwik/api/lifecycle/PropertyAttributes.java
+++ b/api/src/main/java/net/jqwik/api/lifecycle/PropertyAttributes.java
@@ -97,6 +97,15 @@ public interface PropertyAttributes {
 	 */
 	Optional<String> seed();
 
+	/**
+	 * The fixed seed mode of the property at hand.
+	 * Only present when set explicitly through {@linkplain Property#whenFixedSeed()} ()}
+	 * or {@linkplain #setWhenFixedSeed(FixedSeedMode)}.
+	 *
+	 * @return optional fixed seed mode
+	 */
+	Optional<FixedSeedMode> whenFixedSeed();
+
 	void setTries(Integer tries);
 
 	void setMaxDiscardRatio(Integer maxDiscardRatio);
@@ -112,5 +121,7 @@ public interface PropertyAttributes {
 	void setStereotype(String stereotype);
 
 	void setSeed(String seed);
+
+	void setWhenFixedSeed(FixedSeedMode fixedSeedMode);
 
 }

--- a/api/src/main/java/net/jqwik/api/lifecycle/PropertyAttributes.java
+++ b/api/src/main/java/net/jqwik/api/lifecycle/PropertyAttributes.java
@@ -104,6 +104,7 @@ public interface PropertyAttributes {
 	 *
 	 * @return optional fixed seed mode
 	 */
+	@API(status = EXPERIMENTAL, since = "1.4.0")
 	Optional<FixedSeedMode> whenFixedSeed();
 
 	void setTries(Integer tries);

--- a/documentation/src/docs/include/jqwik-configuration.md
+++ b/documentation/src/docs/include/jqwik-configuration.md
@@ -21,6 +21,8 @@ jqwik.shrinking.default = BOUNDED            # Set default shrinking behaviour:
                                              # BOUNDED, FULL, or OFF
 jqwik.shrinking.bounded.seconds = 10         # The maximum number of seconds to shrink if
                                              # shrinking behaviour is set to BOUNDED
+jqwik.seeds.whenfixed = ALLOW                # How a test should act when a seed is fixed. Can set to ALLOW, WARN or FAIL
+                                             # Useful to prevent accidental commits of fixed seeds into source control.                                             
 ```
 
 Prior releases of _jqwik_ used a custom `jqwik.properties`. While this continues to work, it is deprecated

--- a/engine/src/main/java/net/jqwik/engine/DefaultJqwikConfiguration.java
+++ b/engine/src/main/java/net/jqwik/engine/DefaultJqwikConfiguration.java
@@ -33,7 +33,8 @@ public class DefaultJqwikConfiguration implements JqwikConfiguration {
 			properties.defaultGeneration(),
 			properties.defaultEdgeCases(),
 			properties.defaultShrinking(),
-			properties.boundedShrinkingSeconds()
+			properties.boundedShrinkingSeconds(),
+			properties.fixedSeedMode()
 		);
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/JqwikProperties.java
+++ b/engine/src/main/java/net/jqwik/engine/JqwikProperties.java
@@ -61,6 +61,7 @@ public class JqwikProperties {
 	private final EdgeCasesMode defaultEdgeCases;
 	private final ShrinkingMode defaultShrinking;
 	private final int boundedShrinkingSeconds;
+	private final FixedSeedMode fixedSeedMode;
 
 	public String databasePath() {
 		return databasePath;
@@ -106,6 +107,10 @@ public class JqwikProperties {
 		return boundedShrinkingSeconds;
 	}
 
+	public FixedSeedMode fixedSeedMode() {
+		return fixedSeedMode;
+	}
+
 	JqwikProperties(ConfigurationParameters parameters) {
 		databasePath = parameters.get("database").orElse(DEFAULT_DATABASE_PATH);
 		runFailuresFirst = parameters.getBoolean("failures.runfirst").orElse(DEFAULT_RERUN_FAILURES_FIRST);
@@ -118,6 +123,7 @@ public class JqwikProperties {
 		defaultEdgeCases = parameters.get("edgecases.default", EdgeCasesMode::valueOf).orElse(DEFAULT_EDGE_CASES);
 		defaultShrinking = parameters.get("shrinking.default", ShrinkingMode::valueOf).orElse(DEFAULT_SHRINKING);
 		boundedShrinkingSeconds = parameters.get("shrinking.bounded.seconds", Integer::parseInt).orElse(DEFAULT_BOUNDED_SHRINKING_SECONDS);
+		fixedSeedMode = parameters.get("seeds.whenfixed", FixedSeedMode::valueOf).orElse(FixedSeedMode.ALLOW);
 	}
 
 	static JqwikProperties loadWithBackwardsCompatibility(ConfigurationParameters fromJunit) {

--- a/engine/src/main/java/net/jqwik/engine/PropertyAttributesDefaults.java
+++ b/engine/src/main/java/net/jqwik/engine/PropertyAttributesDefaults.java
@@ -14,6 +14,7 @@ public interface PropertyAttributesDefaults {
 	GenerationMode generation();
 	EdgeCasesMode edgeCases();
 	String stereotype();
+	FixedSeedMode whenFixedSeed();
 
 	// This is currently a global parameter
 	int boundedShrinkingSeconds();
@@ -25,7 +26,8 @@ public interface PropertyAttributesDefaults {
 		GenerationMode generationMode,
 		EdgeCasesMode edgeCasesMode,
 		ShrinkingMode shrinkingMode,
-		int boundedShrinkingSeconds
+		int boundedShrinkingSeconds,
+		FixedSeedMode fixedSeedMode
 	) {
 		return new PropertyAttributesDefaults() {
 			@Override
@@ -66,6 +68,11 @@ public interface PropertyAttributesDefaults {
 			@Override
 			public int boundedShrinkingSeconds() {
 				return boundedShrinkingSeconds;
+			}
+
+			@Override
+			public FixedSeedMode whenFixedSeed() {
+				return fixedSeedMode;
 			}
 		};
 	}

--- a/engine/src/main/java/net/jqwik/engine/descriptor/PropertyConfiguration.java
+++ b/engine/src/main/java/net/jqwik/engine/descriptor/PropertyConfiguration.java
@@ -144,4 +144,8 @@ public class PropertyConfiguration {
 	public int boundedShrinkingSeconds() {
 		return propertyAttributesDefaults.boundedShrinkingSeconds();
 	}
+
+	public FixedSeedMode getFixedSeedMode() {
+		return propertyAttributes.whenFixedSeed().orElse(propertyAttributesDefaults.whenFixedSeed());
+	}
 }

--- a/engine/src/main/java/net/jqwik/engine/discovery/DefaultPropertyAttributes.java
+++ b/engine/src/main/java/net/jqwik/engine/discovery/DefaultPropertyAttributes.java
@@ -39,6 +39,10 @@ public class DefaultPropertyAttributes implements PropertyAttributes {
 						  ? null
 						  : property.seed();
 
+		FixedSeedMode whenFixedSeed = property.whenFixedSeed() == FixedSeedMode.NOT_SET
+											  ? null
+											  : property.whenFixedSeed();
+
 		return new DefaultPropertyAttributes(
 			tries,
 			maxDiscardRatio,
@@ -47,7 +51,8 @@ public class DefaultPropertyAttributes implements PropertyAttributes {
 			afterFailure,
 			edgeCases,
 			stereotype,
-			seed
+			seed,
+			whenFixedSeed
 		);
 	}
 
@@ -59,17 +64,19 @@ public class DefaultPropertyAttributes implements PropertyAttributes {
 	private EdgeCasesMode edgeCasesMode;
 	private String stereotype;
 	private String seed;
+	private FixedSeedMode whenFixedSeed;
 
 	// Only public for testing purposes
 	public DefaultPropertyAttributes(
-		Integer tries,
-		Integer maxDiscardRatio,
-		ShrinkingMode shrinkingMode,
-		GenerationMode generationMode,
-		AfterFailureMode afterFailureMode,
-		EdgeCasesMode edgeCasesMode,
-		String stereotype,
-		String seed
+			Integer tries,
+			Integer maxDiscardRatio,
+			ShrinkingMode shrinkingMode,
+			GenerationMode generationMode,
+			AfterFailureMode afterFailureMode,
+			EdgeCasesMode edgeCasesMode,
+			String stereotype,
+			String seed,
+			FixedSeedMode whenFixedSeed
 	) {
 		this.tries = tries;
 		this.maxDiscardRatio = maxDiscardRatio;
@@ -79,6 +86,7 @@ public class DefaultPropertyAttributes implements PropertyAttributes {
 		this.edgeCasesMode = edgeCasesMode;
 		this.stereotype = stereotype;
 		this.seed = seed;
+		this.whenFixedSeed = whenFixedSeed;
 	}
 
 	@Override
@@ -122,6 +130,11 @@ public class DefaultPropertyAttributes implements PropertyAttributes {
 	}
 
 	@Override
+	public Optional<FixedSeedMode> whenFixedSeed() {
+		return Optional.ofNullable(whenFixedSeed);
+	}
+
+	@Override
 	public void setTries(Integer tries) {
 		this.tries = tries;
 	}
@@ -159,5 +172,10 @@ public class DefaultPropertyAttributes implements PropertyAttributes {
 	@Override
 	public void setSeed(String seed) {
 		this.seed = seed;
+	}
+
+	@Override
+	public void setWhenFixedSeed(FixedSeedMode fixedSeedMode) {
+		this.whenFixedSeed = fixedSeedMode;
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/execution/CheckedProperty.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/CheckedProperty.java
@@ -59,25 +59,24 @@ public class CheckedProperty {
 		try {
 			effectiveConfiguration = configurationWithEffectiveSeed();
 		} catch (FailOnFixedSeedException failOnFixedSeedException) {
-			return PropertyCheckResult.failed(
-					configuration.getStereotype(), propertyName, 0, 0,
-					configuration.getSeed(), configuration.getGenerationMode(),
-					configuration.getEdgeCasesMode(), 0, 0,
-					null, null, failOnFixedSeedException
-			);
+			return failed(configuration, failOnFixedSeedException);
 		}
 		maybeWarnOnMultipleTriesWithoutForallParameters(effectiveConfiguration);
 		try {
 			Reporter reporter = propertyLifecycleContext.reporter();
 			return createGenericProperty(effectiveConfiguration).check(reporter, reporting);
 		} catch (CannotFindArbitraryException cannotFindArbitraryException) {
-			return PropertyCheckResult.failed(
-					effectiveConfiguration.getStereotype(), propertyName, 0, 0,
-					effectiveConfiguration.getSeed(), configuration.getGenerationMode(),
-					configuration.getEdgeCasesMode(), 0, 0,
-					null, null, cannotFindArbitraryException
-			);
+			return failed(effectiveConfiguration, cannotFindArbitraryException);
 		}
+	}
+
+	private PropertyCheckResult failed(PropertyConfiguration configuration, JqwikException exception) {
+		return PropertyCheckResult.failed(
+				configuration.getStereotype(), propertyName, 0, 0,
+				configuration.getSeed(), configuration.getGenerationMode(),
+				configuration.getEdgeCasesMode(), 0, 0,
+				null, null, exception
+		);
 	}
 
 	private void maybeWarnOnMultipleTriesWithoutForallParameters(PropertyConfiguration effectiveConfiguration) {

--- a/engine/src/main/java/net/jqwik/engine/execution/CheckedProperty.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/CheckedProperty.java
@@ -95,7 +95,18 @@ public class CheckedProperty {
 
 	private PropertyConfiguration configurationWithEffectiveSeed() {
 		if (!configuration.getSeed().equals(Property.SEED_NOT_SET)) {
-			if(configuration.getFixedSeedMode() == FixedSeedMode.FAIL) {
+			applyFixedSeedMode();
+			return configuration.withSeed(configuration.getSeed());
+		}
+		if (configuration.getPreviousSeed() != null && configuration.getAfterFailureMode() != AfterFailureMode.RANDOM_SEED) {
+			return configuration.withSeed(configuration.getPreviousSeed());
+		}
+		return configuration.withSeed(SourceOfRandomness.createRandomSeed());
+	}
+
+	private void applyFixedSeedMode() {
+		switch (configuration.getFixedSeedMode()) {
+			case FAIL: {
 				String message = String.format(
 						"Failing %s [%s] in container [%s] as the fixed seed mode is set to FAIL",
 						configuration.getStereotype(),
@@ -103,7 +114,8 @@ public class CheckedProperty {
 						propertyLifecycleContext.containerClass().getName()
 				);
 				throw new FailOnFixedSeedException(message);
-			} else if(configuration.getFixedSeedMode() == FixedSeedMode.WARN) {
+			}
+			case WARN: {
 				String message = String.format(
 						"Using fixed seed for %s [%s] in container [%s]",
 						configuration.getStereotype(),
@@ -111,13 +123,9 @@ public class CheckedProperty {
 						propertyLifecycleContext.containerClass().getName()
 				);
 				LOG.warning(message);
+				break;
 			}
-			return configuration.withSeed(configuration.getSeed());
 		}
-		if (configuration.getPreviousSeed() != null && configuration.getAfterFailureMode() != AfterFailureMode.RANDOM_SEED) {
-			return configuration.withSeed(configuration.getPreviousSeed());
-		}
-		return configuration.withSeed(SourceOfRandomness.createRandomSeed());
 	}
 
 	private GenericProperty createGenericProperty(PropertyConfiguration configuration) {

--- a/engine/src/main/java/net/jqwik/engine/execution/reporting/ExecutionResultReport.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/reporting/ExecutionResultReport.java
@@ -21,6 +21,7 @@ public class ExecutionResultReport {
 	private static final String EDGE_CASES_TOTAL_KEY = "edge-cases#total";
 	private static final String EDGE_CASES_TRIED_KEY = "edge-cases#tried";
 	private static final String AFTER_FAILURE_KEY = "after-failure";
+	private static final String FIXED_SEED_KEY = "when-fixed-seed";
 	private static final String SEED_KEY = "seed";
 	private static final String SAMPLE_HEADLINE = "Sample";
 	private static final String SHRUNK_SAMPLE_HEADLINE = "Shrunk Sample";
@@ -31,21 +32,23 @@ public class ExecutionResultReport {
 		ExtendedPropertyExecutionResult executionResult
 	) {
 		return buildJqwikReport(
-			methodDescriptor.getConfiguration().getAfterFailureMode(),
-			methodDescriptor.getTargetMethod(),
-			executionResult
+				methodDescriptor.getConfiguration().getAfterFailureMode(),
+				methodDescriptor.getConfiguration().getFixedSeedMode(),
+				methodDescriptor.getTargetMethod(),
+				executionResult
 		);
 	}
 
 	private static String buildJqwikReport(
-		AfterFailureMode afterFailureMode,
-		Method propertyMethod,
-		ExtendedPropertyExecutionResult executionResult
+			AfterFailureMode afterFailureMode,
+			FixedSeedMode fixedSeedMode,
+			Method propertyMethod,
+			ExtendedPropertyExecutionResult executionResult
 	) {
 		StringBuilder reportLines = new StringBuilder();
 
 		appendThrowableMessage(reportLines, executionResult);
-		appendFixedSizedProperties(reportLines, executionResult, afterFailureMode);
+		appendFixedSizedProperties(reportLines, executionResult, afterFailureMode, fixedSeedMode);
 		appendSamples(reportLines, propertyMethod, executionResult);
 
 		return reportLines.toString();
@@ -100,9 +103,10 @@ public class ExecutionResultReport {
 	}
 
 	private static void appendFixedSizedProperties(
-		StringBuilder reportLines,
-		ExtendedPropertyExecutionResult executionResult,
-		AfterFailureMode afterFailureMode
+			StringBuilder reportLines,
+			ExtendedPropertyExecutionResult executionResult,
+			AfterFailureMode afterFailureMode,
+			FixedSeedMode fixedSeedMode
 	) {
 		List<String> propertiesLines = new ArrayList<>();
 		int countTries = 0;
@@ -128,6 +132,9 @@ public class ExecutionResultReport {
 		appendProperty(propertiesLines, GENERATION_KEY, generationMode, helpGenerationMode);
 		if (afterFailureMode != AfterFailureMode.NOT_SET) {
 			appendProperty(propertiesLines, AFTER_FAILURE_KEY, afterFailureMode.name(), helpAfterFailureMode(afterFailureMode));
+		}
+		if (fixedSeedMode != FixedSeedMode.NOT_SET) {
+			appendProperty(propertiesLines, FIXED_SEED_KEY, fixedSeedMode.name(), helpFixedSeedMode(fixedSeedMode));
 		}
 		appendProperty(propertiesLines, EDGE_CASES_MODE_KEY, edgeCasesMode, helpEdgeCasesMode);
 		if (executionResult.edgeCases().mode().activated()) {
@@ -183,6 +190,19 @@ public class ExecutionResultReport {
 				return "try previously failed sample, then previous seed";
 			default:
 				return "RANDOM_SEED, PREVIOUS_SEED or SAMPLE_FIRST";
+		}
+	}
+
+	private static String helpFixedSeedMode(FixedSeedMode fixedSeedMode) {
+		switch (fixedSeedMode) {
+			case ALLOW:
+				return "allow fixing the random seed";
+			case FAIL:
+				return "fail when fixed random seed";
+			case WARN:
+				return "warn when fixed random seed";
+			default:
+				return "ALLOW, FAIL or WARN";
 		}
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/FailOnFixedSeedException.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/FailOnFixedSeedException.java
@@ -1,0 +1,9 @@
+package net.jqwik.engine.properties;
+
+import net.jqwik.api.*;
+
+public class FailOnFixedSeedException extends JqwikException {
+	public FailOnFixedSeedException(String message) {
+		super(message);
+	}
+}

--- a/engine/src/test/java/net/jqwik/engine/JqwikPropertiesTests.java
+++ b/engine/src/test/java/net/jqwik/engine/JqwikPropertiesTests.java
@@ -50,5 +50,7 @@ class JqwikPropertiesTests {
 		assertThat(properties.defaultShrinking()).isEqualTo(ShrinkingMode.BOUNDED);
 
 		assertThat(properties.boundedShrinkingSeconds()).isEqualTo(10);
+
+		assertThat(properties.fixedSeedMode()).isEqualTo(FixedSeedMode.ALLOW);
 	}
 }

--- a/engine/src/test/java/net/jqwik/engine/TestHelper.java
+++ b/engine/src/test/java/net/jqwik/engine/TestHelper.java
@@ -27,6 +27,7 @@ public class TestHelper {
 	public static final GenerationMode DEFAULT_GENERATION = GenerationMode.AUTO;
 	public static final EdgeCasesMode DEFAULT_EDGE_CASES = EdgeCasesMode.MIXIN;
 	public static final ShrinkingMode DEFAULT_SHRINKING = ShrinkingMode.BOUNDED;
+	public static final FixedSeedMode DEFAULT_WHEN_FIXED_SEED = FixedSeedMode.ALLOW;
 
 	public static PropertyAttributesDefaults propertyAttributesDefaults() {
 		return PropertyAttributesDefaults.with(
@@ -36,7 +37,8 @@ public class TestHelper {
 			DEFAULT_GENERATION,
 			DEFAULT_EDGE_CASES,
 			DEFAULT_SHRINKING,
-			BOUNDED_SHRINKING_SECONDS
+			BOUNDED_SHRINKING_SECONDS,
+			DEFAULT_WHEN_FIXED_SEED
 		);
 	}
 
@@ -81,7 +83,8 @@ public class TestHelper {
 			null,
 			null,
 			null,
-			seed
+			seed,
+			null
 		);
 
 		PropertyConfiguration propertyConfig = new PropertyConfiguration(

--- a/engine/src/test/java/net/jqwik/engine/properties/CheckedPropertyTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/CheckedPropertyTests.java
@@ -154,6 +154,24 @@ class CheckedPropertyTests {
 		}
 
 		@Example
+		void usingFailOnFixedSeedWillFailWithExplicitSeed() {
+			CheckedProperty checkedProperty = createCheckedProperty(
+				"prop1",
+				p -> fail("should not be called"),
+				Collections.emptyList(),
+				p -> fail("should not be called"),
+				Optional.empty(),
+				aConfig().withSeed("414243").withWhenFixedSeed(FixedSeedMode.FAIL).build(),
+				lifecycleContextForMethod("prop1", int.class)
+			);
+
+			PropertyCheckResult check = checkedProperty.check(new Reporting[0]);
+			assertThat(check.checkStatus()).isEqualTo(FAILED);
+			assertThat(check.throwable()).isPresent();
+			assertThat(check.throwable().get()).isInstanceOf(FailOnFixedSeedException.class);
+		}
+
+		@Example
 		void usingASeedWillAlwaysProvideSameArbitraryValues() {
 			List<Integer> allGeneratedInts = new ArrayList<>();
 			CheckedFunction addIntToList = params -> allGeneratedInts.add((int) params.get(0));

--- a/engine/src/test/java/net/jqwik/engine/properties/PropertyConfigurationBuilder.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/PropertyConfigurationBuilder.java
@@ -23,7 +23,7 @@ class PropertyConfigurationBuilder {
 	private GenerationMode generationMode = null;
 	private AfterFailureMode afterFailureMode = null;
 	private EdgeCasesMode edgeCasesMode = null;
-
+	private FixedSeedMode fixedSeedMode = null;
 
 	PropertyConfigurationBuilder withSeed(String seed) {
 		this.seed = seed;
@@ -64,8 +64,14 @@ class PropertyConfigurationBuilder {
 		this.afterFailureMode = afterFailureMode;
 		return this;
 	}
+
 	public PropertyConfigurationBuilder withEdgeCases(EdgeCasesMode edgeCasesMode) {
 		this.edgeCasesMode = edgeCasesMode;
+		return this;
+	}
+
+	public PropertyConfigurationBuilder withWhenFixedSeed(FixedSeedMode fixedSeedMode) {
+		this.fixedSeedMode = fixedSeedMode;
 		return this;
 	}
 
@@ -78,7 +84,8 @@ class PropertyConfigurationBuilder {
 			afterFailureMode,
 			edgeCasesMode,
 			null,
-			seed
+			seed,
+			fixedSeedMode
 		);
 
 		return new PropertyConfiguration(


### PR DESCRIPTION
introduce a `FixedSeedMode` that can be set globally (via properties)
or on an individual test. this allows control of using the `seed`
argument on a property, as it can be undesirable to accidentally commit
a value in this field after reproducing a failure.

fix for #138 
