### PR TITLE
Removed default generation of Date/Calendar

### DIFF
--- a/documentation/src/docs/include/time-module.md
+++ b/documentation/src/docs/include/time-module.md
@@ -7,7 +7,7 @@ This module is part of jqwik's default dependencies.
 
 The date generation is in an extra module which have to be add in a project's dependency.
 By default, years between 1900 and 2500 are generated. You can change this by setting min/max values.
-You can create an arbitrary for date values by using `@ForAll` annotation to date specific types (`LocalDate`, `Calendar`, `Date`, `MonthDay`, `Period`, `Year` and `YearMonth`) or by calling a static method on class `Dates`:
+You can create an arbitrary for date values by using `@ForAll` annotation to date specific types (`LocalDate`, `MonthDay`, `Period`, `Year` and `YearMonth`) or by calling a static method on class `Dates`:
 
 - [`LocalDateArbitrary dates()`](/docs/${docsVersion}/javadoc/net/jqwik/time/api/Dates.html#dates())
 - [`CalendarArbitrary datesAsCalendar()`](/docs/${docsVersion}/javadoc/net/jqwik/time/api/Dates.html#datesAsCalendar())

--- a/time/src/main/java/net/jqwik/time/api/arbitraries/PeriodArbitrary.java
+++ b/time/src/main/java/net/jqwik/time/api/arbitraries/PeriodArbitrary.java
@@ -11,7 +11,7 @@ import static org.apiguardian.api.API.Status.*;
 /**
  * Fluent interface to configure the generation of period values.
  */
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public interface PeriodArbitrary extends Arbitrary<Period> {
 
 	/**

--- a/time/src/main/java/net/jqwik/time/api/constraints/DayOfMonthRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/DayOfMonthRange.java
@@ -23,7 +23,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface DayOfMonthRange {
 	int min() default 1;
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/DayOfWeekRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/DayOfWeekRange.java
@@ -24,7 +24,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface DayOfWeekRange {
 	DayOfWeek min() default DayOfWeek.MONDAY;
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/LeapYears.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/LeapYears.java
@@ -23,7 +23,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface LeapYears {
 	boolean withLeapYears() default true;
 }

--- a/time/src/main/java/net/jqwik/time/api/constraints/MonthDayRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/MonthDayRange.java
@@ -23,7 +23,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface MonthDayRange {
 	String min() default "--01-01";
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/MonthRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/MonthRange.java
@@ -24,7 +24,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface MonthRange {
 	Month min() default Month.JANUARY;
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/PeriodDayRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/PeriodDayRange.java
@@ -18,7 +18,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface PeriodDayRange {
 	int min() default 0;
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/PeriodMonthRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/PeriodMonthRange.java
@@ -18,7 +18,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface PeriodMonthRange {
 	int min() default 0;
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/PeriodYearRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/PeriodYearRange.java
@@ -18,7 +18,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface PeriodYearRange {
 	int min() default Integer.MIN_VALUE;
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/YearMonthRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/YearMonthRange.java
@@ -23,7 +23,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface YearMonthRange {
 	String min() default "1900-01";
 

--- a/time/src/main/java/net/jqwik/time/api/constraints/YearRange.java
+++ b/time/src/main/java/net/jqwik/time/api/constraints/YearRange.java
@@ -23,7 +23,7 @@ import static org.apiguardian.api.API.Status.*;
 @Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@API(status = EXPERIMENTAL, since = "1.4.1")
+@API(status = EXPERIMENTAL, since = "1.4.0")
 public @interface YearRange {
 	int min() default 1900;
 

--- a/time/src/main/java/net/jqwik/time/internal/properties/providers/DatesArbitraryProvider.java
+++ b/time/src/main/java/net/jqwik/time/internal/properties/providers/DatesArbitraryProvider.java
@@ -10,18 +10,13 @@ import net.jqwik.time.api.*;
 public class DatesArbitraryProvider implements ArbitraryProvider {
 	@Override
 	public boolean canProvideFor(TypeUsage targetType) {
-		return targetType.isAssignableFrom(LocalDate.class) || targetType.isAssignableFrom(Calendar.class) || targetType
-																													  .isAssignableFrom(Date.class);
+		return targetType.isAssignableFrom(LocalDate.class);
 	}
 
 	@Override
 	public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
 		if (targetType.isAssignableFrom(LocalDate.class)) {
 			return Collections.singleton(Dates.dates());
-		} else if (targetType.isAssignableFrom(Calendar.class)) {
-			return Collections.singleton(Dates.datesAsCalendar());
-		} else if (targetType.isAssignableFrom(Date.class)) {
-			return Collections.singleton(Dates.datesAsDate());
 		} else {
 			return null;
 		}

--- a/time/src/test/java/net/jqwik/time/api/CalendarTests.java
+++ b/time/src/test/java/net/jqwik/time/api/CalendarTests.java
@@ -32,7 +32,8 @@ class CalendarTests {
 	@Group
 	class SimpleAnnotations {
 
-		@Disabled //Disabled when default generation was removed. TODO: Enable when it is available again
+		@Disabled("Disabled when default generation was removed. Will be enabled when default generation becomes available again.")
+		//TODO: Enable when it is available again.
 		@Property
 		void validCalendarIsGenerated(@ForAll Calendar calendar) {
 			assertThat(calendar).isNotNull();

--- a/time/src/test/java/net/jqwik/time/api/CalendarTests.java
+++ b/time/src/test/java/net/jqwik/time/api/CalendarTests.java
@@ -32,7 +32,7 @@ class CalendarTests {
 	@Group
 	class SimpleAnnotations {
 
-		@Disabled
+		@Disabled //Disabled when default generation was removed. TODO: Enable when it is available again
 		@Property
 		void validCalendarIsGenerated(@ForAll Calendar calendar) {
 			assertThat(calendar).isNotNull();

--- a/time/src/test/java/net/jqwik/time/api/CalendarTests.java
+++ b/time/src/test/java/net/jqwik/time/api/CalendarTests.java
@@ -32,13 +32,14 @@ class CalendarTests {
 	@Group
 	class SimpleAnnotations {
 
+		@Disabled
 		@Property
 		void validCalendarIsGenerated(@ForAll Calendar calendar) {
 			assertThat(calendar).isNotNull();
 		}
 
 		@Property
-		void noLeapYearIsGenerated(@ForAll @LeapYears(withLeapYears = false) Calendar calendar) {
+		void noLeapYearIsGenerated(@ForAll("dates") @LeapYears(withLeapYears = false) Calendar calendar) {
 			assertThat(new GregorianCalendar().isLeapYear(calendar.get(Calendar.YEAR))).isFalse();
 		}
 

--- a/time/src/test/java/net/jqwik/time/api/ConstraintTests.java
+++ b/time/src/test/java/net/jqwik/time/api/ConstraintTests.java
@@ -92,7 +92,7 @@ public class ConstraintTests {
 	@Group
 	class CalendarConstraints {
 
-		//TODO: remove when @ForAll is available
+		//TODO: use default generation is when it is available again
 		@Provide
 		CalendarArbitrary dates() {
 			return Dates.datesAsCalendar();
@@ -174,7 +174,7 @@ public class ConstraintTests {
 	@Group
 	class DateConstraints {
 
-		//TODO: remove when @ForAll is available
+		//TODO: use default generation is when it is available again
 		@Provide
 		DateArbitrary dates() {
 			return Dates.datesAsDate();

--- a/time/src/test/java/net/jqwik/time/api/ConstraintTests.java
+++ b/time/src/test/java/net/jqwik/time/api/ConstraintTests.java
@@ -92,7 +92,7 @@ public class ConstraintTests {
 	@Group
 	class CalendarConstraints {
 
-		//TODO: use default generation is when it is available again
+		//TODO: use default generation when it is available again
 		@Provide
 		CalendarArbitrary dates() {
 			return Dates.datesAsCalendar();
@@ -174,7 +174,7 @@ public class ConstraintTests {
 	@Group
 	class DateConstraints {
 
-		//TODO: use default generation is when it is available again
+		//TODO: use default generation when it is available again
 		@Provide
 		DateArbitrary dates() {
 			return Dates.datesAsDate();

--- a/time/src/test/java/net/jqwik/time/api/ConstraintTests.java
+++ b/time/src/test/java/net/jqwik/time/api/ConstraintTests.java
@@ -6,6 +6,7 @@ import java.util.*;
 
 import net.jqwik.api.*;
 import net.jqwik.testing.*;
+import net.jqwik.time.api.arbitraries.*;
 import net.jqwik.time.api.constraints.*;
 import net.jqwik.time.internal.properties.arbitraries.*;
 
@@ -91,8 +92,14 @@ public class ConstraintTests {
 	@Group
 	class CalendarConstraints {
 
+		//TODO: remove when @ForAll is available
+		@Provide
+		CalendarArbitrary dates() {
+			return Dates.datesAsCalendar();
+		}
+
 		@Property
-		void dateRangeBetween(@ForAll @DateRange(min = "2013-05-25", max = "2020-08-23") Calendar calendar) {
+		void dateRangeBetween(@ForAll("dates") @DateRange(min = "2013-05-25", max = "2020-08-23") Calendar calendar) {
 			Calendar calendarStart = CalendarTests.getCalendar(2013, Calendar.MAY, 25);
 			Calendar calendarEnd = CalendarTests.getCalendar(2020, Calendar.AUGUST, 23);
 			assertThat(calendar).isGreaterThanOrEqualTo(calendarStart);
@@ -100,35 +107,35 @@ public class ConstraintTests {
 		}
 
 		@Property
-		void yearRangeBetween500And700(@ForAll @YearRange(min = 500, max = 700) Calendar calendar) {
+		void yearRangeBetween500And700(@ForAll("dates") @YearRange(min = 500, max = 700) Calendar calendar) {
 			assertThat(calendar.get(Calendar.YEAR)).isGreaterThanOrEqualTo(500);
 			assertThat(calendar.get(Calendar.YEAR)).isLessThanOrEqualTo(700);
 		}
 
 		@Property
-		void monthRangeBetweenMarchAndJuly(@ForAll @MonthRange(min = Month.MARCH, max = Month.JULY) Calendar calendar) {
+		void monthRangeBetweenMarchAndJuly(@ForAll("dates") @MonthRange(min = Month.MARCH, max = Month.JULY) Calendar calendar) {
 			assertThat(DefaultCalendarArbitrary.calendarMonthToMonth(calendar)).isGreaterThanOrEqualTo(Month.MARCH);
 			assertThat(DefaultCalendarArbitrary.calendarMonthToMonth(calendar)).isLessThanOrEqualTo(Month.JULY);
 		}
 
 		@Property
-		void dayOfMonthRangeBetween15And20Integer(@ForAll @DayOfMonthRange(min = 15, max = 20) Calendar calendar) {
+		void dayOfMonthRangeBetween15And20Integer(@ForAll("dates") @DayOfMonthRange(min = 15, max = 20) Calendar calendar) {
 			assertThat(calendar.get(Calendar.DAY_OF_MONTH)).isGreaterThanOrEqualTo(15);
 			assertThat(calendar.get(Calendar.DAY_OF_MONTH)).isLessThanOrEqualTo(20);
 		}
 
 		@Property
-		void dayOfWeekRangeOnlyMonday(@ForAll @DayOfWeekRange(max = DayOfWeek.MONDAY) Calendar calendar) {
+		void dayOfWeekRangeOnlyMonday(@ForAll("dates") @DayOfWeekRange(max = DayOfWeek.MONDAY) Calendar calendar) {
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(calendar)).isEqualTo(DayOfWeek.MONDAY);
 		}
 
 		@Property
-		void dayOfWeekRangeOnlySunday(@ForAll @DayOfWeekRange(min = DayOfWeek.SUNDAY) Calendar calendar) {
+		void dayOfWeekRangeOnlySunday(@ForAll("dates") @DayOfWeekRange(min = DayOfWeek.SUNDAY) Calendar calendar) {
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(calendar)).isEqualTo(DayOfWeek.SUNDAY);
 		}
 
 		@Property
-		void dayOfWeekRangeBetweenTuesdayAndFriday(@ForAll @DayOfWeekRange(min = DayOfWeek.TUESDAY, max = DayOfWeek.FRIDAY) Calendar calendar) {
+		void dayOfWeekRangeBetweenTuesdayAndFriday(@ForAll("dates") @DayOfWeekRange(min = DayOfWeek.TUESDAY, max = DayOfWeek.FRIDAY) Calendar calendar) {
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(calendar)).isGreaterThanOrEqualTo(DayOfWeek.TUESDAY);
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(calendar)).isLessThanOrEqualTo(DayOfWeek.FRIDAY);
 		}
@@ -138,25 +145,25 @@ public class ConstraintTests {
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException1(@ForAll @DateRange(min = "2013-05") Calendar date) {
+			void dateRangeThrowsException1(@ForAll("dates") @DateRange(min = "2013-05") Calendar date) {
 				//do nothing
 			}
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException2(@ForAll @DateRange(min = "foo") Calendar date) {
+			void dateRangeThrowsException2(@ForAll("dates") @DateRange(min = "foo") Calendar date) {
 				//do nothing
 			}
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException3(@ForAll @DateRange(max = "--05-25") Calendar date) {
+			void dateRangeThrowsException3(@ForAll("dates") @DateRange(max = "--05-25") Calendar date) {
 				//do nothing
 			}
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException4(@ForAll @DateRange(max = "13") Calendar date) {
+			void dateRangeThrowsException4(@ForAll("dates") @DateRange(max = "13") Calendar date) {
 				//do nothing
 			}
 
@@ -167,8 +174,14 @@ public class ConstraintTests {
 	@Group
 	class DateConstraints {
 
+		//TODO: remove when @ForAll is available
+		@Provide
+		DateArbitrary dates() {
+			return Dates.datesAsDate();
+		}
+
 		@Property
-		void dateRangeBetween(@ForAll @DateRange(min = "2013-05-25", max = "2020-08-23") Date date) {
+		void dateRangeBetween(@ForAll("dates") @DateRange(min = "2013-05-25", max = "2020-08-23") Date date) {
 			Date dateStart = DateTests.getDate(2013, Calendar.MAY, 25);
 			Date dateEnd = DateTests.getDate(2020, Calendar.AUGUST, 23);
 			assertThat(date).isAfterOrEqualTo(dateStart);
@@ -176,35 +189,35 @@ public class ConstraintTests {
 		}
 
 		@Property
-		void yearRangeBetween500And700(@ForAll @YearRange(min = 500, max = 700) Date date) {
+		void yearRangeBetween500And700(@ForAll("dates") @YearRange(min = 500, max = 700) Date date) {
 			assertThat(dateToCalendar(date).get(Calendar.YEAR)).isGreaterThanOrEqualTo(500);
 			assertThat(dateToCalendar(date).get(Calendar.YEAR)).isLessThanOrEqualTo(700);
 		}
 
 		@Property
-		void monthRangeBetweenMarchAndJuly(@ForAll @MonthRange(min = Month.MARCH, max = Month.JULY) Date date) {
+		void monthRangeBetweenMarchAndJuly(@ForAll("dates") @MonthRange(min = Month.MARCH, max = Month.JULY) Date date) {
 			assertThat(DefaultCalendarArbitrary.calendarMonthToMonth(dateToCalendar(date))).isGreaterThanOrEqualTo(Month.MARCH);
 			assertThat(DefaultCalendarArbitrary.calendarMonthToMonth(dateToCalendar(date))).isLessThanOrEqualTo(Month.JULY);
 		}
 
 		@Property
-		void dayOfMonthRangeBetween15And20Integer(@ForAll @DayOfMonthRange(min = 15, max = 20) Date date) {
+		void dayOfMonthRangeBetween15And20Integer(@ForAll("dates") @DayOfMonthRange(min = 15, max = 20) Date date) {
 			assertThat(dateToCalendar(date).get(Calendar.DAY_OF_MONTH)).isGreaterThanOrEqualTo(15);
 			assertThat(dateToCalendar(date).get(Calendar.DAY_OF_MONTH)).isLessThanOrEqualTo(20);
 		}
 
 		@Property
-		void dayOfWeekRangeOnlyMonday(@ForAll @DayOfWeekRange(max = DayOfWeek.MONDAY) Date date) {
+		void dayOfWeekRangeOnlyMonday(@ForAll("dates") @DayOfWeekRange(max = DayOfWeek.MONDAY) Date date) {
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(dateToCalendar(date))).isEqualTo(DayOfWeek.MONDAY);
 		}
 
 		@Property
-		void dayOfWeekRangeOnlySunday(@ForAll @DayOfWeekRange(min = DayOfWeek.SUNDAY) Date date) {
+		void dayOfWeekRangeOnlySunday(@ForAll("dates") @DayOfWeekRange(min = DayOfWeek.SUNDAY) Date date) {
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(dateToCalendar(date))).isEqualTo(DayOfWeek.SUNDAY);
 		}
 
 		@Property
-		void dayOfWeekRangeBetweenTuesdayAndFriday(@ForAll @DayOfWeekRange(min = DayOfWeek.TUESDAY, max = DayOfWeek.FRIDAY) Date date) {
+		void dayOfWeekRangeBetweenTuesdayAndFriday(@ForAll("dates") @DayOfWeekRange(min = DayOfWeek.TUESDAY, max = DayOfWeek.FRIDAY) Date date) {
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(dateToCalendar(date)))
 					.isGreaterThanOrEqualTo(DayOfWeek.TUESDAY);
 			assertThat(DefaultCalendarArbitrary.calendarDayOfWeekToDayOfWeek(dateToCalendar(date))).isLessThanOrEqualTo(DayOfWeek.FRIDAY);
@@ -221,25 +234,25 @@ public class ConstraintTests {
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException1(@ForAll @DateRange(min = "2013-05") Date date) {
+			void dateRangeThrowsException1(@ForAll("dates") @DateRange(min = "2013-05") Date date) {
 				//do nothing
 			}
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException2(@ForAll @DateRange(min = "foo") Date date) {
+			void dateRangeThrowsException2(@ForAll("dates") @DateRange(min = "foo") Date date) {
 				//do nothing
 			}
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException3(@ForAll @DateRange(max = "--05-25") Date date) {
+			void dateRangeThrowsException3(@ForAll("dates") @DateRange(max = "--05-25") Date date) {
 				//do nothing
 			}
 
 			@Example
 			@ExpectFailure(failureType = DateTimeParseException.class)
-			void dateRangeThrowsException4(@ForAll @DateRange(max = "13") Date date) {
+			void dateRangeThrowsException4(@ForAll("dates") @DateRange(max = "13") Date date) {
 				//do nothing
 			}
 

--- a/time/src/test/java/net/jqwik/time/api/DateTests.java
+++ b/time/src/test/java/net/jqwik/time/api/DateTests.java
@@ -38,13 +38,14 @@ class DateTests {
 	@Group
 	class SimpleAnnotations {
 
+		@Disabled
 		@Property
 		void validCalendarIsGenerated(@ForAll Date date) {
 			assertThat(date).isNotNull();
 		}
 
 		@Property
-		void noLeapYearIsGenerated(@ForAll @LeapYears(withLeapYears = false) Date date) {
+		void noLeapYearIsGenerated(@ForAll("dates") @LeapYears(withLeapYears = false) Date date) {
 			assertThat(new GregorianCalendar().isLeapYear(dateToCalendar(date).get(Calendar.YEAR))).isFalse();
 		}
 

--- a/time/src/test/java/net/jqwik/time/api/DateTests.java
+++ b/time/src/test/java/net/jqwik/time/api/DateTests.java
@@ -38,7 +38,8 @@ class DateTests {
 	@Group
 	class SimpleAnnotations {
 
-		@Disabled //Disabled when default generation was removed. TODO: Enable when it is available again
+		@Disabled("Disabled when default generation was removed. Will be enabled when default generation becomes available again.")
+		//TODO: Enable when it is available again.
 		@Property
 		void validDateIsGenerated(@ForAll Date date) {
 			assertThat(date).isNotNull();

--- a/time/src/test/java/net/jqwik/time/api/DateTests.java
+++ b/time/src/test/java/net/jqwik/time/api/DateTests.java
@@ -38,7 +38,7 @@ class DateTests {
 	@Group
 	class SimpleAnnotations {
 
-		@Disabled
+		@Disabled //Disabled when default generation was removed. TODO: Enable when it is available again
 		@Property
 		void validDateIsGenerated(@ForAll Date date) {
 			assertThat(date).isNotNull();

--- a/time/src/test/java/net/jqwik/time/api/DateTests.java
+++ b/time/src/test/java/net/jqwik/time/api/DateTests.java
@@ -25,7 +25,7 @@ class DateTests {
 	}
 
 	@Property
-	void validCalendarIsGenerated(@ForAll("dates") Date date) {
+	void validDateIsGenerated(@ForAll("dates") Date date) {
 		assertThat(date).isNotNull();
 	}
 
@@ -40,7 +40,7 @@ class DateTests {
 
 		@Disabled
 		@Property
-		void validCalendarIsGenerated(@ForAll Date date) {
+		void validDateIsGenerated(@ForAll Date date) {
 			assertThat(date).isNotNull();
 		}
 


### PR DESCRIPTION
Removed the default generation of date and calendar to add it later again. (When generation of time is included)
