### PR TITLE
add docs to say "Users should use `net.jqwik.api.Tag` rather than `org.junit.jupiter.api.Tag`"

### DIFF
--- a/docs/docs/snapshot/user-guide.md
+++ b/docs/docs/snapshot/user-guide.md
@@ -1015,7 +1015,8 @@ class TaggingExamples {
 ```
 
 Tags must follow certain rules as described
-[here](/docs/snapshot/javadoc/net/jqwik/api/Tag.html)
+[here](/docs/snapshot/javadoc/net/jqwik/api/Tag.html). Noted that the `@Tag` you'll
+have to use with jqwik is `net.jqwik.api.Tag` rather than `org.junit.jupiter.api.Tag`
 
 ### Disabling Tests
 


### PR DESCRIPTION
## Overview

The junit 5 `org.junit.jupiter.api.Tag` does not work for jqwik and the replacement is `net.jqwik.api.Tag`. It seems to me that it is worth adding a doc for annotation interpretation.

### Details

I file this PR for (https://github.com/apache/kafka/pull/10791). Kafka leverages jqwik to write tests for new module and I just noticed that junit 5 tag is not compatible to jqwik.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
