### PR TITLE
use a data-structure more appropriate for frequently retrieving stores

### DIFF
--- a/engine/src/test/java/net/jqwik/engine/execution/lifecycle/StoreRepositoryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/execution/lifecycle/StoreRepositoryTests.java
@@ -66,7 +66,7 @@ class StoreRepositoryTests {
 			assertThat(optionalStore1).isPresent();
 
 			Optional<ScopedStore<String>> optionalStore2 = repository.get(container2, "aString");
-			assertThat(optionalStore1).isPresent();
+			assertThat(optionalStore2).isPresent();
 
 			assertThat(optionalStore1).isNotEqualTo(optionalStore2);
 		}


### PR DESCRIPTION
## Overview

This ist _not_ a ready-to-use fix for the issue - it solves the problem partially and has yet to be verified in a larger context.
At least for my most pathological test class I'm back down to ~10s from 1m45s (1.5.2: ~6s).
So it might be nevertheless good enough for an inspiration.

### Details

There are still some things I find suspicious though:
* I don't expect that many calls to `StoreRepository#get` (relative to the number of tries)
* I don't expect a (slow but) steady increase in entries for a given test during execution of the tries
* The test execution time increases by 20x when I increase the tries by 10x (1.000 -> 10.000)
* The implementation has still room for improvement for the other public methods

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
