### PR TITLE
Fix link into vavr-test

### DIFF
--- a/docs/property-based-testing.md
+++ b/docs/property-based-testing.md
@@ -36,7 +36,7 @@ There are a few alternatives to _jqwik_ if you want to do PBT on the JVM:
 - [QuickTheories](https://github.com/ncredinburgh/QuickTheories):
   Unlike other systems QuickTheories supports both shrinking and targeted search using coverage data.
 - [Vavr](http://www.vavr.io/): The functional library also comes with a 
-  [property-based testing module](https://github.com/vavr-io/vavr/tree/master/vavr-test).
+  [property-based testing module](https://github.com/vavr-io/vavr-test).
 - [jetCheck](https://github.com/JetBrains/jetCheck): A property-based testing library for Java 8+. 
   Works with any testing framework.
 - [ScalaCheck](http://www.scalacheck.org/): A mature property based testing system with shrinking and all, 


### PR DESCRIPTION
## Overview

Module `vavr-test` was moved out from `vavr` in vavr-io/vavr-test@8523bf55f12ade9de3f0179a0724910c125063b6.

---
I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
