### PR TITLE
Change SampleStreamFacade static generators to LruCache

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/facades/SampleStreamFacade.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/SampleStreamFacade.java
@@ -25,7 +25,7 @@ class SampleStreamFacade {
 		}
 	};
 
-	private static final Map<Arbitrary<Object>, RandomGenerator<Object>> generators = new HashMap<>();
+	private static final Map<Arbitrary<Object>, RandomGenerator<Object>> generators = new GeneratorLruCache(500);
 
 	@SuppressWarnings("unchecked")
 	private static <T> RandomGenerator<T> getGeneratorForSampling(Arbitrary<T> arbitrary) {
@@ -68,4 +68,17 @@ class SampleStreamFacade {
 					 .map(shrinkable -> runInDescriptor(() -> shrinkable.value()));
 	}
 
+	private static class GeneratorLruCache extends LinkedHashMap<Arbitrary<Object>, RandomGenerator<Object>> {
+		private final int maxSize;
+
+		GeneratorLruCache(int maxSize) {
+			super(maxSize + 1, 1, true);
+			this.maxSize = maxSize;
+		}
+
+		@Override
+		protected boolean removeEldestEntry(Map.Entry<Arbitrary<Object>, RandomGenerator<Object>> eldest) {
+			return size() > maxSize;
+		}
+	}
 }


### PR DESCRIPTION
## Overview

Change to LruCache so that data is not continuously accumulated in the static HashMap of SampleStreamFacade .

### Details

In SampleStreamFacade, generator is cached in static HashMap.
If many kinds of Arbitrary are created(with EdgeCases), a lot of data can be accumulated in HashMap.
Change to LruCache to avoid accumulating too much data.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
