### PR TITLE
Change Memoize cache to LruCache

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/facades/Memoize.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/Memoize.java
@@ -10,7 +10,7 @@ import net.jqwik.api.lifecycle.*;
 class Memoize {
 
 	private static Store<Map<Tuple3<Arbitrary<?>, Integer, Boolean>, RandomGenerator<?>>> generatorStore() {
-		return Store.getOrCreate(Memoize.class, Lifespan.PROPERTY, HashMap::new);
+		return Store.getOrCreate(Memoize.class, Lifespan.PROPERTY, () -> new MemoizeLruCache<>(500));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -47,4 +47,17 @@ class Memoize {
 		return result;
 	}
 
+	private static class MemoizeLruCache<K, V> extends LinkedHashMap<K, V> {
+		private final int maxSize;
+
+		MemoizeLruCache(int maxSize) {
+			super(maxSize + 1, 1, true);
+			this.maxSize = maxSize;
+		}
+
+		@Override
+		protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+			return size() > maxSize;
+		}
+	}
 }


### PR DESCRIPTION
## Overview

Change to LruCache so that data is not continuously accumulated in the static Store HashMap of Memoize .

### Details

Memoize #memodizedGenerator caches RandomGenerator to Memoize HashMap as many as the number of Arbitrary types (`Tuple3<Arbitrary<?>, Integer, Boolean>`).
When many kinds of Arbitrary are created, Random Generators accumulate in Map.
Change to prevent accumulation of too many Random Generators with LRU Cache.


---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
