### PR TITLE
Configure version to be included in module descriptors

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -7,6 +7,7 @@ jar {
 
 moduleConfig {
 	moduleInfoPath = 'src/main/module/module-info.java' // don't confuse IDEs
+	version = "${jqwikVersion}"
 	neverCompileModuleInfo = true
 }
 

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -7,6 +7,7 @@ jar {
 
 moduleConfig {
 	moduleInfoPath = 'src/main/module/module-info.java' // don't confuse IDEs
+	version = "${jqwikVersion}"
 	neverCompileModuleInfo = true
 }
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -7,6 +7,7 @@ jar {
 
 moduleConfig {
 	moduleInfoPath = 'src/main/module/module-info.java' // don't confuse IDEs
+	version = "${jqwikVersion}"
 	neverCompileModuleInfo = true
 }
 

--- a/kotlin/build.gradle
+++ b/kotlin/build.gradle
@@ -12,6 +12,7 @@ jar {
 
 moduleConfig {
 	moduleInfoPath = 'src/main/module/module-info.java' // don't confuse IDEs
+	version = "${jqwikVersion}"
 	neverCompileModuleInfo = true
 }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -7,6 +7,7 @@ jar {
 
 moduleConfig {
 	moduleInfoPath = 'src/main/module/module-info.java' // don't confuse IDEs
+	version = "${jqwikVersion}"
 	neverCompileModuleInfo = true
 }
 

--- a/time/build.gradle
+++ b/time/build.gradle
@@ -7,6 +7,7 @@ jar {
 
 moduleConfig {
 	moduleInfoPath = 'src/main/module/module-info.java' // don't confuse IDEs
+	version = "${jqwikVersion}"
 	neverCompileModuleInfo = true
 }
 

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -7,6 +7,7 @@ jar {
 
 moduleConfig {
 	moduleInfoPath = 'src/main/module/module-info.java' // don't confuse IDEs
+	version = "${jqwikVersion}"
 	neverCompileModuleInfo = true
 }
 


### PR DESCRIPTION
Due to an update of the default behaviour of beryx's module plugin to no longer include project's version as module version, this PR adds explicit configurations to achieve that.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
