### PR TITLE
fix typos in documentation

### DIFF
--- a/documentation/src/docs/include/generation-from-type.md
+++ b/documentation/src/docs/include/generation-from-type.md
@@ -32,7 +32,7 @@ public class Person {
 ```
 
 A first step to use arbitrarily generated `Person` objects without having
-to write a lot of _jqwik_-specific boiler plat code could look like that:
+to write a lot of _jqwik_-specific boiler plate code could look like that:
 
 ```java
 @Property

--- a/documentation/src/docs/include/kotlin-module.md
+++ b/documentation/src/docs/include/kotlin-module.md
@@ -49,16 +49,16 @@ dependencies {
     testImplementation("net.jqwik:jqwik-kotlin:${version}")
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs = listOf(
-			"-Xjsr305=strict", // Required for strict interpretation of
-			"-Xemit-jvm-type-annotations" // Required for annotations on type variables
-		)
+            "-Xjsr305=strict", // Required for strict interpretation of
+            "-Xemit-jvm-type-annotations" // Required for annotations on type variables
+        )
         jvmTarget = "11" // 1.8 or above
         javaParameters = true // Required to get correct parameter names in reporting
     }
@@ -121,7 +121,7 @@ Here are a few of those which I noticed to be relevant for jqwik:
               fun propertyInInnerGroup(@ForAll anInt: Int) {}
           }
       }
-  }  
+  }
   ```
 
 - Just like abstract classes and interfaces Kotlin's _sealed_ classes


### PR DESCRIPTION
Hi Johannes,

I'm planning to implement InputStream tests for https://github.com/pgjdbc/pgjdbc/pull/2389, and I discovered a couple of typos in the documentation.

The doc is great: it does list up-to-date jqwik version, the samples look good.

What I plan to implement is a mix of `Stateful Testing` and `Contract Tests`.
In other words, I have a golden implementation (e.g. `ByteArrayInputStream`), and I would verify if my `InputStream` yields the same (or comparable) outputs where the operations are `read(), read(byte[]), read(byte[], int, int), mark(int), reset()`.

It would be great to decouple `InputStreamProperty` from `pgjdbc`, so `InputStreamProperty` could be contributed back to jqwick.

---

...migrated to https://github.com/jlink/jqwik/issues/288


---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
