### PR TITLE
Avoid recursion in CombinedIterator

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/support/combinatorics/CombinedIterator.java
+++ b/engine/src/main/java/net/jqwik/engine/support/combinatorics/CombinedIterator.java
@@ -54,8 +54,14 @@ public class CombinedIterator<T> implements Iterator<List<T>> {
 	}
 
 	private void resetValuesFrom(int startPosition) {
+		List<Iterator<T>> iterators = this.iterators;
+		List<Iterable<T>> iterables = this.iterables;
+		List<T> elements = this.elements;
+		// In the initial reset, we can reuse the existing iterators
+		// It might slightly optimize the behavior, and it supports Stream#iterator which can't be executed twice
+		boolean initialReset = position == -1;
 		for (int i = startPosition; i < iterables.size(); i++) {
-			Iterator<T> newIt = iterables.get(i).iterator();
+			Iterator<T> newIt = initialReset ? iterators.get(i) : iterables.get(i).iterator();
 			iterators.set(i, newIt);
 			elements.set(i, newIt.next());
 		}
@@ -63,6 +69,7 @@ public class CombinedIterator<T> implements Iterator<List<T>> {
 	}
 
 	private int nextAvailablePosition() {
+		List<Iterator<T>> iterators = this.iterators;
 		for (int i = position; i >= 0; i--) {
 			if (iterators.get(i).hasNext()) {
 				return i;

--- a/engine/src/main/java/net/jqwik/engine/support/combinatorics/CombinedIterator.java
+++ b/engine/src/main/java/net/jqwik/engine/support/combinatorics/CombinedIterator.java
@@ -2,62 +2,73 @@ package net.jqwik.engine.support.combinatorics;
 
 import java.util.ArrayList;
 import java.util.*;
-
-import static java.util.Arrays.*;
+import java.util.stream.*;
 
 public class CombinedIterator<T> implements Iterator<List<T>> {
-
-	private final Iterator<T> first;
-	private final ArrayList<Iterable<T>> rest;
-	private Iterator<List<T>> next;
-
-	private T current = null;
-
-	// This must be tracked because there can be null values
-	private boolean currentIsSet = false;
+	private final List<Iterable<T>> iterables;
+	private final List<Iterator<T>> iterators;
+	private final List<T> elements;
+	private final boolean isEmpty;
+	private int position = -1;
 
 	public CombinedIterator(List<Iterable<T>> iterables) {
-		this.rest = new ArrayList<>(iterables);
-		this.first = this.rest.remove(0).iterator();
-		this.next = restIterator();
-	}
-
-	private Iterator<List<T>> restIterator() {
-		return this.rest.isEmpty()
-				   ? emptyListIterator()
-				   : new CombinedIterator<>(this.rest);
-	}
-
-	private Iterator<List<T>> emptyListIterator() {
-		return asList(Collections.<T>emptyList()).iterator();
+		this.iterables = iterables;
+		elements = new ArrayList<>(Collections.nCopies(iterables.size(), null));
+		iterators = iterables.stream().map(Iterable::iterator).collect(Collectors.toCollection(ArrayList::new));
+		isEmpty = !iterators.stream().allMatch(Iterator::hasNext);
 	}
 
 	@Override
 	public boolean hasNext() {
-		if (currentIsSet) {
-			return next.hasNext() || first.hasNext();
-		} else {
-			return next.hasNext() && first.hasNext();
+		if (isEmpty) {
+			return false;
 		}
+		return position == -1 || nextAvailablePosition() != -1;
 	}
 
 	@Override
 	public List<T> next() {
-		if (next.hasNext()) {
-			if (!currentIsSet) {
-				current = first.next();
-				currentIsSet = true;
-			}
-		} else {
-			current = first.next();
-			this.next = restIterator();
+		if (isEmpty) {
+			throw new NoSuchElementException();
 		}
-		return prepend(current, next.next());
+		if (position == -1) {
+			// The first initialization of the values
+			resetValuesUpTo(elements.size());
+		} else {
+			Iterator<T> it = iterators.get(position);
+			if (it.hasNext()) {
+				// Just advance the current iterator
+				elements.set(position, it.next());
+			} else {
+				// Advance the next iterator, and reset [0..nextPosition)
+				position++;
+				int nextPosition = nextAvailablePosition();
+				if (nextPosition == -1) {
+					throw new NoSuchElementException();
+				}
+				elements.set(nextPosition, iterators.get(nextPosition).next());
+				resetValuesUpTo(nextPosition);
+			}
+		}
+		return new ArrayList<>(elements);
 	}
 
-	private List<T> prepend(T head, List<T> tail) {
-		List<T> rest = new ArrayList<>(tail);
-		rest.add(0, head);
-		return rest;
+	private void resetValuesUpTo(int nextPosition) {
+		for (int i = 0; i < nextPosition; i++) {
+			Iterator<T> newIt = iterables.get(i).iterator();
+			iterators.set(i, newIt);
+			elements.set(i, newIt.next());
+		}
+		position = 0;
+	}
+
+	private int nextAvailablePosition() {
+		int size = iterators.size();
+		for (int i = position; i < size; i++) {
+			if (iterators.get(i).hasNext()) {
+				return i;
+			}
+		}
+		return -1;
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/support/combinatorics/CombinedIterator.java
+++ b/engine/src/main/java/net/jqwik/engine/support/combinatorics/CombinedIterator.java
@@ -33,38 +33,37 @@ public class CombinedIterator<T> implements Iterator<List<T>> {
 		}
 		if (position == -1) {
 			// The first initialization of the values
-			resetValuesUpTo(elements.size());
+			resetValuesFrom(0);
 		} else {
 			Iterator<T> it = iterators.get(position);
 			if (it.hasNext()) {
 				// Just advance the current iterator
 				elements.set(position, it.next());
 			} else {
-				// Advance the next iterator, and reset [0..nextPosition)
-				position++;
+				// Advance the next iterator, and reset (nextPosition, size)
+				position--;
 				int nextPosition = nextAvailablePosition();
 				if (nextPosition == -1) {
 					throw new NoSuchElementException();
 				}
 				elements.set(nextPosition, iterators.get(nextPosition).next());
-				resetValuesUpTo(nextPosition);
+				resetValuesFrom(nextPosition + 1);
 			}
 		}
 		return new ArrayList<>(elements);
 	}
 
-	private void resetValuesUpTo(int nextPosition) {
-		for (int i = 0; i < nextPosition; i++) {
+	private void resetValuesFrom(int startPosition) {
+		for (int i = startPosition; i < iterables.size(); i++) {
 			Iterator<T> newIt = iterables.get(i).iterator();
 			iterators.set(i, newIt);
 			elements.set(i, newIt.next());
 		}
-		position = 0;
+		position = iterables.size() - 1;
 	}
 
 	private int nextAvailablePosition() {
-		int size = iterators.size();
-		for (int i = position; i < size; i++) {
+		for (int i = position; i >= 0; i--) {
 			if (iterators.get(i).hasNext()) {
 				return i;
 			}


### PR DESCRIPTION
Previously, CombinedIterator#next copied the list as many times
as there were elements in the list (each recursive call did copy the list).

Now only a single copy is made.

It improves performance, and it makes stacktraces easier to understand.

fixes #342

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
