### PR TITLE
Improve FeatureExtractor: use contains for identity extractors, and avoid building intermediate sets

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/properties/FeatureExtractor.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/FeatureExtractor.java
@@ -20,12 +20,17 @@ public interface FeatureExtractor<T> extends Function<T, Object> {
 	}
 
 	default boolean isUniqueIn(T value, Collection<T> elements) {
-		Set<Object> elementFeatures = elements.stream().map(this::applySafe).collect(Collectors.toSet());
-		return !elementFeatures.contains(this.applySafe(value));
+		if (this == identity()) {
+			return !elements.contains(value);
+		}
+		Object feature = applySafe(value);
+		return elements.stream()
+					   .map(this::applySafe)
+					   .noneMatch(x -> Objects.equals(x, feature));
 	}
 
 	default boolean areUnique(Collection<T> elements) {
-		Set<Object> elementFeatures = elements.stream().map(this::applySafe).collect(Collectors.toSet());
-		return elementFeatures.size() == elements.size();
+		long uniqueCount = elements.stream().map(this::applySafe).distinct().count();
+		return uniqueCount == elements.size();
 	}
 }


### PR DESCRIPTION
Previously, FeatureExtractor built an itermediate set for a sole purpose
of uniqueness check.

The change delegates to .contains(value) for the common case of identity extractor,
and we use noneMatch to avoid building the set for non-default extractors.

It might be that ContainerGenerator requires improvements to keep per-feature
sets, however, the current fix is a low-hanging fruit.

fixes #333

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
