### PR TITLE
Add de.thetaphi.forbiddenapis to avoid usage of unwanted APIs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,6 +54,8 @@
     - JqwikSession:
       - setRandomSessionSeed(), getRandomSessionSeed()
 
+    - Rework net.jqwik.engine.execution.JqwikExecutor.letNonSuccessfulTestsExecuteFirst to avoid O(m*n)
+
     - Allow state machine / model specification with temporal logic.
       See https://wickstrom.tech/programming/2021/05/03/specifying-state-machines-with-temporal-logic.html
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -14,4 +14,5 @@ repositories {
 
 dependencies {
 	implementation 'com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:1.78'
+	implementation("de.thetaphi.forbiddenapis:de.thetaphi.forbiddenapis.gradle.plugin:3.3")
 }

--- a/buildSrc/src/main/groovy/jqwik.common-configuration.gradle
+++ b/buildSrc/src/main/groovy/jqwik.common-configuration.gradle
@@ -4,6 +4,7 @@ plugins {
 	id 'signing'
 	// See https://github.com/vlsi/vlsi-release-plugins/blob/master/plugins/gradle-extensions-plugin/README.md
 	id 'com.github.vlsi.gradle-extensions'
+	id 'jqwik.forbidden-apis'
 }
 
 repositories {

--- a/buildSrc/src/main/groovy/jqwik.forbidden-apis.gradle
+++ b/buildSrc/src/main/groovy/jqwik.forbidden-apis.gradle
@@ -1,0 +1,17 @@
+plugins {
+	id 'de.thetaphi.forbiddenapis'
+}
+
+// See https://github.com/policeman-tools/forbidden-apis/wiki/GradleUsage
+project.forbiddenApis {
+	project.java.toolchain
+	def configDir = rootProject.layout.projectDirectory.dir("config")
+	signaturesFiles.from({
+		def sourceVersion = project.java.sourceCompatibility
+		def res = [configDir.file("forbidden-apis.txt")]
+		if (sourceVersion.isJava10Compatible()) {
+			res += configDir.file("forbidden-apis-jdk10.txt")
+		}
+		res
+	})
+}

--- a/config/forbidden-apis-jdk10.txt
+++ b/config/forbidden-apis-jdk10.txt
@@ -1,0 +1,10 @@
+# See https://github.com/policeman-tools/forbidden-apis/wiki/SignaturesSyntax
+# forbidden-apis fails in case it can't resolve a signature (e.g. method not found),
+# so we have to split configurations for signatures introduced in newer Jave versions
+
+@defaultMessage Prefer Collections.toCollection(LinkedHashSet::new) for reproducible order of the results
+java.util.stream.Collectors#toUnmodifiableSet()
+
+@defaultMessage Prefer Collections.toMap(.., LinkedHashMap::new) for reproducible order of the results
+java.util.stream.Collectors#toUnmodifiableMap(java.util.function.Function, java.util.function.Function)
+java.util.stream.Collectors#toUnmodifiableMap(java.util.function.Function, java.util.function.Function, java.util.function.BinaryOperator)

--- a/config/forbidden-apis.txt
+++ b/config/forbidden-apis.txt
@@ -1,0 +1,14 @@
+# See https://github.com/policeman-tools/forbidden-apis/wiki/SignaturesSyntax
+
+@defaultMessage Prefer Collections.toCollection(LinkedHashSet::new) for reproducible order of the results
+java.util.stream.Collectors#toSet()
+
+@defaultMessage Prefer Collections.toMap(.., LinkedHashMap::new) for reproducible order of the results
+java.util.stream.Collectors#toMap(java.util.function.Function, java.util.function.Function)
+java.util.stream.Collectors#toMap(java.util.function.Function, java.util.function.Function, java.util.function.BinaryOperator)
+
+@defaultMessage Prefer LinkedHashSet() for reproducible order of the results
+java.util.HashSet#<init>(**)
+
+@defaultMessage Prefer LinkedHashMap() for reproducible order of the results
+java.util.HashMap#<init>(**)

--- a/documentation/src/test/java/net/jqwik/docs/contracts/eurocalc/RateProviderContractProperties.java
+++ b/documentation/src/test/java/net/jqwik/docs/contracts/eurocalc/RateProviderContractProperties.java
@@ -41,7 +41,7 @@ class RateProviderContractProperties {
 	// Constraints should be checked during precondition checking of a contract
 	static class CurrencyConstraint implements Constraint<String> {
 
-		private final Set<String> currencies = new HashSet<String>() {
+		private final Set<String> currencies = new LinkedHashSet<String>() {
 			{
 				add("EUR");
 				add("USD");

--- a/documentation/src/test/java/net/jqwik/docs/state/mystore/MyStore.java
+++ b/documentation/src/test/java/net/jqwik/docs/state/mystore/MyStore.java
@@ -35,14 +35,14 @@ public class MyStore<K, V> {
 	}
 
 	public Set<K> keys() {
-		return tuples.stream().map(Tuple1::get1).collect(Collectors.toSet());
+		return tuples.stream().map(Tuple1::get1).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	@Override
 	public String toString() {
 		Set<String> contents = keys().stream()
 									 .map(k -> String.format("%s=%s", k, get(k).orElse(null)))
-									 .collect(Collectors.toSet());
+									 .collect(Collectors.toCollection(LinkedHashSet::new));
 		return String.format("Store %s", contents);
 	}
 }

--- a/documentation/src/test/java/net/jqwik/docs/state/mystore/MyStoreExamples.java
+++ b/documentation/src/test/java/net/jqwik/docs/state/mystore/MyStoreExamples.java
@@ -104,7 +104,7 @@ public class MyStoreExamples {
 		private Set<Tuple.Tuple2<K, V>> entries(MyStore<K, V> before) {
 			return before.keys().stream()
 						 .map(key -> Tuple.of(key, before.get(key).orElse(null)))
-						 .collect(Collectors.toSet());
+						 .collect(Collectors.toCollection(LinkedHashSet::new));
 		}
 
 		@Override

--- a/engine/src/main/java/net/jqwik/engine/DefaultJqwikConfiguration.java
+++ b/engine/src/main/java/net/jqwik/engine/DefaultJqwikConfiguration.java
@@ -9,6 +9,8 @@ import org.junit.platform.engine.*;
 
 import net.jqwik.engine.recording.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 public class DefaultJqwikConfiguration implements JqwikConfiguration {
 
 	private static final Logger LOG = Logger.getLogger(JqwikConfiguration.class.getName());
@@ -102,7 +104,7 @@ public class DefaultJqwikConfiguration implements JqwikConfiguration {
 			public Set<UniqueId> previousFailures() {
 				if (!properties.runFailuresFirst())
 					return Collections.emptySet();
-				return previousRun.allNonSuccessfulTests().map(TestRun::getUniqueId).collect(Collectors.toSet());
+				return previousRun.allNonSuccessfulTests().map(TestRun::getUniqueId).collect(toLinkedHashSet());
 			}
 		};
 	}

--- a/engine/src/main/java/net/jqwik/engine/DefaultJqwikConfiguration.java
+++ b/engine/src/main/java/net/jqwik/engine/DefaultJqwikConfiguration.java
@@ -3,13 +3,11 @@ package net.jqwik.engine;
 import java.nio.file.*;
 import java.util.*;
 import java.util.logging.*;
-import java.util.stream.*;
 
 import org.junit.platform.engine.*;
 
 import net.jqwik.engine.recording.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
+import net.jqwik.engine.support.*;
 
 public class DefaultJqwikConfiguration implements JqwikConfiguration {
 
@@ -104,7 +102,7 @@ public class DefaultJqwikConfiguration implements JqwikConfiguration {
 			public Set<UniqueId> previousFailures() {
 				if (!properties.runFailuresFirst())
 					return Collections.emptySet();
-				return previousRun.allNonSuccessfulTests().map(TestRun::getUniqueId).collect(toLinkedHashSet());
+				return previousRun.allNonSuccessfulTests().map(TestRun::getUniqueId).collect(JqwikCollectors.toLinkedHashSet());
 			}
 		};
 	}

--- a/engine/src/main/java/net/jqwik/engine/descriptor/DiscoverySupport.java
+++ b/engine/src/main/java/net/jqwik/engine/descriptor/DiscoverySupport.java
@@ -40,7 +40,7 @@ public class DiscoverySupport {
 	}
 
 	public static Set<Domain> findDomains(AnnotatedElement element) {
-		return new HashSet<>(findRepeatableAnnotations(element, Domain.class));
+		return new LinkedHashSet<>(findRepeatableAnnotations(element, Domain.class));
 	}
 
 	public static String determineLabel(AnnotatedElement element, Supplier<String> defaultNameSupplier) {

--- a/engine/src/main/java/net/jqwik/engine/discovery/HierarchicalJavaResolver.java
+++ b/engine/src/main/java/net/jqwik/engine/discovery/HierarchicalJavaResolver.java
@@ -14,10 +14,6 @@ import net.jqwik.engine.discovery.predicates.*;
 import net.jqwik.engine.support.*;
 
 import static java.lang.String.*;
-import static java.util.stream.Collectors.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
-
 import static org.junit.platform.commons.support.HierarchyTraversalMode.*;
 import static org.junit.platform.commons.support.ReflectionSupport.*;
 import static org.junit.platform.engine.SelectorResolutionResult.*;
@@ -176,7 +172,7 @@ class HierarchicalJavaResolver {
 				   .map(resolver -> tryToResolveWithResolver(element, parent, resolver))
 				   .filter(testDescriptors -> !testDescriptors.isEmpty())
 				   .flatMap(Collection::stream)
-				   .collect(toLinkedHashSet());
+				   .collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	private Set<TestDescriptor> tryToResolveWithResolver(AnnotatedElement element, TestDescriptor parent, ElementResolver resolver) {

--- a/engine/src/main/java/net/jqwik/engine/discovery/HierarchicalJavaResolver.java
+++ b/engine/src/main/java/net/jqwik/engine/discovery/HierarchicalJavaResolver.java
@@ -15,6 +15,9 @@ import net.jqwik.engine.support.*;
 
 import static java.lang.String.*;
 import static java.util.stream.Collectors.*;
+
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 import static org.junit.platform.commons.support.HierarchyTraversalMode.*;
 import static org.junit.platform.commons.support.ReflectionSupport.*;
 import static org.junit.platform.engine.SelectorResolutionResult.*;
@@ -173,7 +176,7 @@ class HierarchicalJavaResolver {
 				   .map(resolver -> tryToResolveWithResolver(element, parent, resolver))
 				   .filter(testDescriptors -> !testDescriptors.isEmpty())
 				   .flatMap(Collection::stream)
-				   .collect(toSet());
+				   .collect(toLinkedHashSet());
 	}
 
 	private Set<TestDescriptor> tryToResolveWithResolver(AnnotatedElement element, TestDescriptor parent, ElementResolver resolver) {

--- a/engine/src/main/java/net/jqwik/engine/discovery/HierarchicalJavaResolver.java
+++ b/engine/src/main/java/net/jqwik/engine/discovery/HierarchicalJavaResolver.java
@@ -143,7 +143,7 @@ class HierarchicalJavaResolver {
 	}
 
 	private Set<TestDescriptor> resolveForAllParents(AnnotatedElement element, Set<TestDescriptor> potentialParents) {
-		Set<TestDescriptor> resolvedDescriptors = new HashSet<>();
+		Set<TestDescriptor> resolvedDescriptors = new LinkedHashSet<>();
 		potentialParents.forEach(parent -> resolvedDescriptors.addAll(resolve(element, parent)));
 		return resolvedDescriptors;
 	}

--- a/engine/src/main/java/net/jqwik/engine/discovery/JqwikDiscoverer.java
+++ b/engine/src/main/java/net/jqwik/engine/discovery/JqwikDiscoverer.java
@@ -103,7 +103,7 @@ public class JqwikDiscoverer {
 	}
 
 	private HierarchicalJavaResolver createHierarchicalResolver(TestDescriptor engineDescriptor) {
-		Set<ElementResolver> resolvers = new HashSet<>();
+		Set<ElementResolver> resolvers = new LinkedHashSet<>();
 		resolvers.add(new TopLevelContainerResolver());
 		resolvers.add(new GroupContainerResolver());
 		resolvers.add(new PropertyMethodResolver(testRunData, propertyDefaultValues));

--- a/engine/src/main/java/net/jqwik/engine/execution/CachingArbitraryResolver.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/CachingArbitraryResolver.java
@@ -10,7 +10,7 @@ import net.jqwik.engine.support.*;
 // Make sure that all property parameters are only resolved once per property run
 public class CachingArbitraryResolver implements ArbitraryResolver {
 
-	private final Map<Parameter, Set<Arbitrary<?>>> cache = new HashMap<>();
+	private final Map<Parameter, Set<Arbitrary<?>>> cache = new LinkedHashMap<>();
 
 	private ArbitraryResolver resolver;
 

--- a/engine/src/main/java/net/jqwik/engine/execution/CombinedDomainContext.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/CombinedDomainContext.java
@@ -14,7 +14,7 @@ class CombinedDomainContext implements DomainContext {
 	private final List<SampleReportingFormat> reportingFormats = new ArrayList<>();
 
 	CombinedDomainContext(Set<DomainContext> domainContexts) {
-		Set<DomainContext> expandedContexts = new HashSet<>(domainContexts);
+		Set<DomainContext> expandedContexts = new LinkedHashSet<>(domainContexts);
 
 		for (DomainContext domainContext : expandedContexts) {
 			providers.addAll(domainContext.getArbitraryProviders());

--- a/engine/src/main/java/net/jqwik/engine/execution/DomainContextFactory.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/DomainContextFactory.java
@@ -9,8 +9,6 @@ import net.jqwik.api.lifecycle.*;
 import net.jqwik.engine.descriptor.*;
 import net.jqwik.engine.support.*;
 
-import static net.jqwik.engine.support.JqwikCollectors.*;
-
 class DomainContextFactory {
 
 	private final PropertyLifecycleContext propertyLifecycleContext;
@@ -40,7 +38,7 @@ class DomainContextFactory {
 				.peek(domainContext -> {
 					domainContext.initialize(propertyLifecycleContext);
 				})
-				.collect(toLinkedHashSet());
+				.collect(JqwikCollectors.toLinkedHashSet());
 		return new CombinedDomainContext(domainContexts);
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/execution/DomainContextFactory.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/DomainContextFactory.java
@@ -9,6 +9,8 @@ import net.jqwik.api.lifecycle.*;
 import net.jqwik.engine.descriptor.*;
 import net.jqwik.engine.support.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 class DomainContextFactory {
 
 	private final PropertyLifecycleContext propertyLifecycleContext;
@@ -38,7 +40,7 @@ class DomainContextFactory {
 				.peek(domainContext -> {
 					domainContext.initialize(propertyLifecycleContext);
 				})
-				.collect(Collectors.toSet());
+				.collect(toLinkedHashSet());
 		return new CombinedDomainContext(domainContexts);
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/execution/JqwikExecutor.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/JqwikExecutor.java
@@ -47,7 +47,10 @@ public class JqwikExecutor {
 	}
 
 	private void letNonSuccessfulTestsExecuteFirst(ExecutionPipeline pipeline) {
-		previousFailedTests.forEach(pipeline::executeFirst);
+		// TODO: avoid O(m*n) in the future
+		List<UniqueId> ids = new ArrayList<>(previousFailedTests);
+		Collections.reverse(ids);
+		ids.forEach(pipeline::executeFirst);
 	}
 
 	private ExecutionTask createTask(TestDescriptor descriptor, Pipeline pipeline, PropertyExecutionListener propertyExecutionListener) {

--- a/engine/src/main/java/net/jqwik/engine/execution/ParameterSupplierResolver.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/ParameterSupplierResolver.java
@@ -8,7 +8,7 @@ import net.jqwik.api.lifecycle.ResolveParameterHook.*;
 import net.jqwik.engine.support.*;
 
 class ParameterSupplierResolver {
-	private final Map<Parameter, Optional<ParameterSupplier>> resolvedSuppliers = new HashMap<>();
+	private final Map<Parameter, Optional<ParameterSupplier>> resolvedSuppliers = new LinkedHashMap<>();
 	private final ResolveParameterHook resolveParameterHook;
 	private final LifecycleContext lifecycleContext;
 

--- a/engine/src/main/java/net/jqwik/engine/execution/PropertyMethodExecutor.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/PropertyMethodExecutor.java
@@ -3,7 +3,6 @@ package net.jqwik.engine.execution;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.logging.*;
-import java.util.stream.*;
 
 import org.junit.platform.commons.support.*;
 import org.junit.platform.engine.*;
@@ -16,8 +15,6 @@ import net.jqwik.engine.execution.lifecycle.*;
 import net.jqwik.engine.execution.reporting.*;
 import net.jqwik.engine.properties.*;
 import net.jqwik.engine.support.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
 
 public class PropertyMethodExecutor {
 
@@ -115,7 +112,7 @@ public class PropertyMethodExecutor {
 	}
 
 	private String buildResultReportKey() {
-		Set<String> tags = methodDescriptor.getTags().stream().map(TestTag::getName).collect(toLinkedHashSet());
+		Set<String> tags = methodDescriptor.getTags().stream().map(TestTag::getName).collect(JqwikCollectors.toLinkedHashSet());
 		String tagsString = tags.isEmpty()
 								? ""
 								: String.format("[%s] ", String.join(", ", tags));

--- a/engine/src/main/java/net/jqwik/engine/execution/PropertyMethodExecutor.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/PropertyMethodExecutor.java
@@ -17,6 +17,8 @@ import net.jqwik.engine.execution.reporting.*;
 import net.jqwik.engine.properties.*;
 import net.jqwik.engine.support.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 public class PropertyMethodExecutor {
 
 	private static final Logger LOG = Logger.getLogger(PropertyMethodExecutor.class.getName());
@@ -113,7 +115,7 @@ public class PropertyMethodExecutor {
 	}
 
 	private String buildResultReportKey() {
-		Set<String> tags = methodDescriptor.getTags().stream().map(TestTag::getName).collect(Collectors.toSet());
+		Set<String> tags = methodDescriptor.getTags().stream().map(TestTag::getName).collect(toLinkedHashSet());
 		String tagsString = tags.isEmpty()
 								? ""
 								: String.format("[%s] ", String.join(", ", tags));

--- a/engine/src/main/java/net/jqwik/engine/execution/lifecycle/LifecycleHooksRegistry.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/lifecycle/LifecycleHooksRegistry.java
@@ -24,7 +24,7 @@ public class LifecycleHooksRegistry implements LifecycleHooksSupplier {
 	}
 
 	private final List<HookRegistration> registrations = new ArrayList<>();
-	private final Map<Class<? extends LifecycleHook>, LifecycleHook> instances = new HashMap<>();
+	private final Map<Class<? extends LifecycleHook>, LifecycleHook> instances = new IdentityHashMap<>();
 
 	@Override
 	public AroundPropertyHook aroundPropertyHook(PropertyMethodDescriptor propertyMethodDescriptor) {

--- a/engine/src/main/java/net/jqwik/engine/execution/lifecycle/StoreRepository.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/lifecycle/StoreRepository.java
@@ -25,7 +25,7 @@ public class StoreRepository {
 		return current;
 	}
 
-	private static class IdentifiedStores extends HashMap<TestDescriptor, ScopedStore<?>> {}
+	private static class IdentifiedStores extends LinkedHashMap<TestDescriptor, ScopedStore<?>> {}
 
 	private final Map<Object, IdentifiedStores> storesByIdentifier = new LinkedHashMap<>();
 

--- a/engine/src/main/java/net/jqwik/engine/execution/lifecycle/StoreRepository.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/lifecycle/StoreRepository.java
@@ -27,7 +27,7 @@ public class StoreRepository {
 
 	private static class IdentifiedStores extends HashMap<TestDescriptor, ScopedStore<?>> {}
 
-	private final Map<Object, IdentifiedStores> storesByIdentifier = new HashMap<>();
+	private final Map<Object, IdentifiedStores> storesByIdentifier = new LinkedHashMap<>();
 
 	public <T> ScopedStore<T> create(
 		TestDescriptor scope,

--- a/engine/src/main/java/net/jqwik/engine/execution/reporting/SampleReportingFormats.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/reporting/SampleReportingFormats.java
@@ -11,7 +11,7 @@ public class SampleReportingFormats {
 	private static final LazyServiceLoaderCache<SampleReportingFormat> serviceCache = new LazyServiceLoaderCache<>(SampleReportingFormat.class);
 
 	public static Collection<SampleReportingFormat> getReportingFormats() {
-		Set<SampleReportingFormat> formats = new HashSet<>();
+		Set<SampleReportingFormat> formats = new LinkedHashSet<>();
 		formats.addAll(getRegisteredReportingFormats());
 		formats.addAll(getReportingFormatsFromCurrentDomainContext());
 

--- a/engine/src/main/java/net/jqwik/engine/facades/ArbitrariesFacadeImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/ArbitrariesFacadeImpl.java
@@ -16,9 +16,9 @@ import net.jqwik.engine.properties.arbitraries.*;
 import net.jqwik.engine.properties.arbitraries.exhaustive.*;
 import net.jqwik.engine.properties.arbitraries.randomized.*;
 import net.jqwik.engine.properties.stateful.*;
+import net.jqwik.engine.support.*;
 
 import static net.jqwik.engine.properties.arbitraries.ArbitrariesSupport.*;
-import static net.jqwik.engine.support.JqwikCollectors.*;
 
 /**
  * Is loaded through reflection in api module
@@ -275,7 +275,7 @@ public class ArbitrariesFacadeImpl extends Arbitraries.ArbitrariesFacade {
 		RegisteredArbitraryConfigurer defaultArbitraryConfigurer = new RegisteredArbitraryConfigurer(domainContext.getArbitraryConfigurators());
 		return unconfiguredArbitraries.stream()
 									  .map(arbitrary -> defaultArbitraryConfigurer.configure(arbitrary, typeUsage))
-									  .collect(toLinkedHashSet());
+									  .collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	private static Set<Arbitrary<?>> createDefaultArbitraries(

--- a/engine/src/main/java/net/jqwik/engine/facades/ArbitrariesFacadeImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/ArbitrariesFacadeImpl.java
@@ -18,6 +18,7 @@ import net.jqwik.engine.properties.arbitraries.randomized.*;
 import net.jqwik.engine.properties.stateful.*;
 
 import static net.jqwik.engine.properties.arbitraries.ArbitrariesSupport.*;
+import static net.jqwik.engine.support.JqwikCollectors.*;
 
 /**
  * Is loaded through reflection in api module
@@ -274,7 +275,7 @@ public class ArbitrariesFacadeImpl extends Arbitraries.ArbitrariesFacade {
 		RegisteredArbitraryConfigurer defaultArbitraryConfigurer = new RegisteredArbitraryConfigurer(domainContext.getArbitraryConfigurators());
 		return unconfiguredArbitraries.stream()
 									  .map(arbitrary -> defaultArbitraryConfigurer.configure(arbitrary, typeUsage))
-									  .collect(Collectors.toSet());
+									  .collect(toLinkedHashSet());
 	}
 
 	private static Set<Arbitrary<?>> createDefaultArbitraries(

--- a/engine/src/main/java/net/jqwik/engine/facades/JavaBeanReportingFormatFacadeImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/JavaBeanReportingFormatFacadeImpl.java
@@ -56,7 +56,7 @@ public class JavaBeanReportingFormatFacadeImpl extends JavaBeanReportingFormat.J
 	}
 
 	private Map<String, Tuple2<String, Method>> toMap(List<Tuple2<String, Method>> properties) {
-		HashMap<String, Tuple2<String, Method>> map = new HashMap<>();
+		HashMap<String, Tuple2<String, Method>> map = new LinkedHashMap<>();
 		for (Tuple2<String, Method> entry : properties) {
 			map.put(entry.get1(), entry);
 		}

--- a/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsCollectorImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsCollectorImpl.java
@@ -14,7 +14,7 @@ import net.jqwik.engine.facades.*;
 public class StatisticsCollectorImpl implements StatisticsCollector {
 	public static final Object COLLECTORS_ID = Tuple.of(StatisticsCollectorImpl.class, "collectors");
 
-	private final Map<List<Object>, Integer> counts = new HashMap<>();
+	private final Map<List<Object>, Integer> counts = new LinkedHashMap<>();
 	private final List<Consumer<StatisticsCoverage>> coverageCheckers = new ArrayList<>();
 	private final String label;
 

--- a/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsHook.java
+++ b/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsHook.java
@@ -13,6 +13,8 @@ import net.jqwik.api.statistics.StatisticsReport.*;
 import net.jqwik.engine.hooks.*;
 import net.jqwik.engine.support.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 public class StatisticsHook implements AroundPropertyHook {
 
 	private static final Logger LOG = Logger.getLogger(StatisticsHook.class.getName());
@@ -78,7 +80,7 @@ public class StatisticsHook implements AroundPropertyHook {
 						  String label = entry.getKey();
 						  return Tuple.of(label, entry.getValue(), determineFormat(label, statisticsReportAnnotations, context, isFailure));
 					  })
-					  .collect(Collectors.toSet());
+					  .collect(toLinkedHashSet());
 
 		report(reports, context.reporter(), context.extendedLabel());
 	}

--- a/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsHook.java
+++ b/engine/src/main/java/net/jqwik/engine/hooks/statistics/StatisticsHook.java
@@ -3,7 +3,6 @@ package net.jqwik.engine.hooks.statistics;
 import java.util.*;
 import java.util.function.*;
 import java.util.logging.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.Tuple.*;
@@ -12,8 +11,6 @@ import net.jqwik.api.statistics.*;
 import net.jqwik.api.statistics.StatisticsReport.*;
 import net.jqwik.engine.hooks.*;
 import net.jqwik.engine.support.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
 
 public class StatisticsHook implements AroundPropertyHook {
 
@@ -80,7 +77,7 @@ public class StatisticsHook implements AroundPropertyHook {
 						  String label = entry.getKey();
 						  return Tuple.of(label, entry.getValue(), determineFormat(label, statisticsReportAnnotations, context, isFailure));
 					  })
-					  .collect(toLinkedHashSet());
+					  .collect(JqwikCollectors.toLinkedHashSet());
 
 		report(reports, context.reporter(), context.extendedLabel());
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/InstanceBasedSubtypeProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/InstanceBasedSubtypeProvider.java
@@ -7,8 +7,8 @@ import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
+import net.jqwik.engine.support.*;
 
-import static net.jqwik.engine.support.JqwikCollectors.*;
 import static net.jqwik.engine.support.JqwikReflectionSupport.*;
 import static net.jqwik.engine.support.OverriddenMethodAnnotationSupport.*;
 
@@ -69,7 +69,7 @@ abstract class InstanceBasedSubtypeProvider implements ArbitraryProvider.Subtype
 				   .stream()
 				   .map(arbitrary -> configure(arbitrary, targetType))
 				   .filter(Objects::nonNull)
-				   .collect(toLinkedHashSet());
+				   .collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	private Set<Arbitrary<?>> resolveFromSupplier(

--- a/engine/src/main/java/net/jqwik/engine/properties/InstanceBasedSubtypeProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/InstanceBasedSubtypeProvider.java
@@ -8,6 +8,7 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
 import static net.jqwik.engine.support.JqwikReflectionSupport.*;
 import static net.jqwik.engine.support.OverriddenMethodAnnotationSupport.*;
 
@@ -68,7 +69,7 @@ abstract class InstanceBasedSubtypeProvider implements ArbitraryProvider.Subtype
 				   .stream()
 				   .map(arbitrary -> configure(arbitrary, targetType))
 				   .filter(Objects::nonNull)
-				   .collect(Collectors.toSet());
+				   .collect(toLinkedHashSet());
 	}
 
 	private Set<Arbitrary<?>> resolveFromSupplier(

--- a/engine/src/main/java/net/jqwik/engine/properties/PropertyCheckResult.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/PropertyCheckResult.java
@@ -307,7 +307,7 @@ public class PropertyCheckResult implements ExtendedPropertyExecutionResult {
 		switch (checkStatus()) {
 			case FAILED:
 				String failedMessage = falsifiedParameters().map(sampleParams -> {
-					Map<Integer, Object> sampleMap = new HashMap<>();
+					Map<Integer, Object> sampleMap = new LinkedHashMap<>();
 					for (int i = 0; i < sampleParams.size(); i++) {
 						Object parameter = sampleParams.get(i);
 						sampleMap.put(i, parameter);

--- a/engine/src/main/java/net/jqwik/engine/properties/ProviderMethodInvoker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/ProviderMethodInvoker.java
@@ -3,7 +3,6 @@ package net.jqwik.engine.properties;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.function.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.ArbitraryProvider.*;
@@ -11,7 +10,6 @@ import net.jqwik.api.providers.*;
 import net.jqwik.engine.support.*;
 import net.jqwik.engine.support.types.*;
 
-import static net.jqwik.engine.support.JqwikCollectors.*;
 import static net.jqwik.engine.support.JqwikReflectionSupport.*;
 
 class ProviderMethodInvoker {
@@ -87,7 +85,7 @@ class ProviderMethodInvoker {
 	}
 
 	private <T, R> Set<R> mapSet(Set<T> invokers, Function<T, R> mapper) {
-		return invokers.stream().map(mapper).collect(toLinkedHashSet());
+		return invokers.stream().map(mapper).collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	private boolean isForAllParameter(MethodParameter parameter) {

--- a/engine/src/main/java/net/jqwik/engine/properties/ProviderMethodInvoker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/ProviderMethodInvoker.java
@@ -11,6 +11,7 @@ import net.jqwik.api.providers.*;
 import net.jqwik.engine.support.*;
 import net.jqwik.engine.support.types.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
 import static net.jqwik.engine.support.JqwikReflectionSupport.*;
 
 class ProviderMethodInvoker {
@@ -86,7 +87,7 @@ class ProviderMethodInvoker {
 	}
 
 	private <T, R> Set<R> mapSet(Set<T> invokers, Function<T, R> mapper) {
-		return invokers.stream().map(mapper).collect(Collectors.toSet());
+		return invokers.stream().map(mapper).collect(toLinkedHashSet());
 	}
 
 	private boolean isForAllParameter(MethodParameter parameter) {

--- a/engine/src/main/java/net/jqwik/engine/properties/PurelyRandomShrinkablesGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/PurelyRandomShrinkablesGenerator.java
@@ -15,7 +15,7 @@ class PurelyRandomShrinkablesGenerator {
 	}
 
 	List<Shrinkable<Object>> generateNext(Random random) {
-		Map<TypeUsage, Arbitrary<Object>> generatorsCache = new HashMap<>();
+		Map<TypeUsage, Arbitrary<Object>> generatorsCache = new LinkedHashMap<>();
 		return parameterGenerators
 				   .stream()
 				   .map(generator -> generator.next(random, generatorsCache))

--- a/engine/src/main/java/net/jqwik/engine/properties/RandomizedShrinkablesGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/RandomizedShrinkablesGenerator.java
@@ -11,6 +11,7 @@ import net.jqwik.engine.support.*;
 import net.jqwik.engine.support.types.*;
 
 import static java.lang.Math.*;
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 
 public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator {
 
@@ -146,7 +147,7 @@ public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator
 		Set<Arbitrary<Object>> arbitraries =
 			arbitraryResolver.forParameter(parameter).stream()
 							 .map(Arbitrary::asGeneric)
-							 .collect(Collectors.toSet());
+							 .collect(toLinkedHashSet());
 		if (arbitraries.isEmpty()) {
 			throw new CannotFindArbitraryException(TypeUsageImpl.forParameter(parameter), parameter.getAnnotation(ForAll.class));
 		}

--- a/engine/src/main/java/net/jqwik/engine/properties/RandomizedShrinkablesGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/RandomizedShrinkablesGenerator.java
@@ -11,7 +11,6 @@ import net.jqwik.engine.support.*;
 import net.jqwik.engine.support.types.*;
 
 import static java.lang.Math.*;
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 
 public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator {
 
@@ -147,7 +146,7 @@ public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator
 		Set<Arbitrary<Object>> arbitraries =
 			arbitraryResolver.forParameter(parameter).stream()
 							 .map(Arbitrary::asGeneric)
-							 .collect(toLinkedHashSet());
+							 .collect(JqwikCollectors.toLinkedHashSet());
 		if (arbitraries.isEmpty()) {
 			throw new CannotFindArbitraryException(TypeUsageImpl.forParameter(parameter), parameter.getAnnotation(ForAll.class));
 		}

--- a/engine/src/main/java/net/jqwik/engine/properties/RegisteredArbitraryResolver.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/RegisteredArbitraryResolver.java
@@ -17,7 +17,7 @@ public class RegisteredArbitraryResolver {
 
 	public Set<Arbitrary<?>> resolve(TypeUsage targetType, SubtypeProvider subtypeProvider) {
 		int currentPriority = Integer.MIN_VALUE;
-		Set<Arbitrary<?>> fittingArbitraries = new HashSet<>();
+		Set<Arbitrary<?>> fittingArbitraries = new LinkedHashSet<>();
 		for (ArbitraryProvider provider : registeredProviders) {
 			if (provider.canProvideFor(targetType)) {
 				if (provider.priority() < currentPriority) {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultDoubleArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultDoubleArbitrary.java
@@ -14,7 +14,7 @@ public class DefaultDoubleArbitrary extends TypedCloneable implements DoubleArbi
 	private static final double DEFAULT_MAX = Double.MAX_VALUE;
 
 	private DecimalGeneratingArbitrary generatingArbitrary;
-	private final Set<Double> specials = new HashSet<>();
+	private final Set<Double> specials = new LinkedHashSet<>();
 
 	public DefaultDoubleArbitrary() {
 		this.generatingArbitrary = new DecimalGeneratingArbitrary(Range.of(toBigDecimal(DEFAULT_MIN), toBigDecimal(DEFAULT_MAX)));

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultFloatArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultFloatArbitrary.java
@@ -14,7 +14,7 @@ public class DefaultFloatArbitrary extends TypedCloneable implements FloatArbitr
 	private static final float DEFAULT_MAX = Float.MAX_VALUE;
 
 	private DecimalGeneratingArbitrary generatingArbitrary;
-	private final Set<Float> specials = new HashSet<>();
+	private final Set<Float> specials = new LinkedHashSet<>();
 
 	public DefaultFloatArbitrary() {
 		this.generatingArbitrary = new DecimalGeneratingArbitrary(Range.of(toBigDecimal(DEFAULT_MIN), toBigDecimal(DEFAULT_MAX)));

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultMapArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultMapArbitrary.java
@@ -56,7 +56,7 @@ public class DefaultMapArbitrary<K, V> extends ArbitraryDecorator<Map<K, V>> imp
 			ListArbitrary<V> valueListArbitrary = createValueListArbitrary(mapSize);
 			return valueListArbitrary.map(
 					values -> {
-						HashMap<K, V> map = new HashMap<>();
+						HashMap<K, V> map = new LinkedHashMap<>();
 						for (int i = 0; i < mapSize; i++) {
 							K key = keys.get(i);
 							V value = values.get(i);

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultMapArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultMapArbitrary.java
@@ -17,8 +17,8 @@ public class DefaultMapArbitrary<K, V> extends ArbitraryDecorator<Map<K, V>> imp
 	private int maxSize = RandomGenerators.DEFAULT_COLLECTION_SIZE;
 	private RandomDistribution sizeDistribution = null;
 
-	private Set<FeatureExtractor<K>> keyUniquenessExtractors = new HashSet<>();
-	private Set<FeatureExtractor<V>> valueUniquenessExtractors = new HashSet<>();
+	private Set<FeatureExtractor<K>> keyUniquenessExtractors = new LinkedHashSet<>();
+	private Set<FeatureExtractor<V>> valueUniquenessExtractors = new LinkedHashSet<>();
 
 	public DefaultMapArbitrary(Arbitrary<K> keysArbitrary, Arbitrary<V> valuesArbitrary) {
 		this.keysArbitrary = keysArbitrary;

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultMapArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultMapArbitrary.java
@@ -86,7 +86,7 @@ public class DefaultMapArbitrary<K, V> extends ArbitraryDecorator<Map<K, V>> imp
 	@Override
 	public MapArbitrary<K, V> uniqueKeys(Function<K, Object> by) {
 		DefaultMapArbitrary<K, V> clone = typedClone();
-		clone.keyUniquenessExtractors = new HashSet<>(keyUniquenessExtractors);
+		clone.keyUniquenessExtractors = new LinkedHashSet<>(keyUniquenessExtractors);
 		clone.keyUniquenessExtractors.add(by::apply);
 		return clone;
 	}
@@ -94,7 +94,7 @@ public class DefaultMapArbitrary<K, V> extends ArbitraryDecorator<Map<K, V>> imp
 	@Override
 	public MapArbitrary<K, V> uniqueValues(Function<V, Object> by) {
 		DefaultMapArbitrary<K, V> clone = typedClone();
-		clone.valueUniquenessExtractors = new HashSet<>(valueUniquenessExtractors);
+		clone.valueUniquenessExtractors = new LinkedHashSet<>(valueUniquenessExtractors);
 		clone.valueUniquenessExtractors.add(by::apply);
 		return clone;
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
@@ -48,7 +48,7 @@ public class DefaultSetArbitrary<T> extends MultivalueArbitraryBase<T, Set<T>> i
 	@Override
 	public EdgeCases<Set<T>> edgeCases(int maxEdgeCases) {
 		return edgeCases((elementList, minSize1) -> {
-			Set<Shrinkable<T>> elementSet = new HashSet<>(elementList);
+			Set<Shrinkable<T>> elementSet = new LinkedHashSet<>(elementList);
 			return new ShrinkableSet<>(elementSet, minSize1, maxSize, uniquenessExtractors);
 		}, maxEdgeCases);
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
@@ -11,6 +11,8 @@ import net.jqwik.engine.properties.arbitraries.exhaustive.*;
 import net.jqwik.engine.properties.arbitraries.randomized.*;
 import net.jqwik.engine.properties.shrinking.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class DefaultSetArbitrary<T> extends MultivalueArbitraryBase<T, Set<T>> implements SetArbitrary<T> {
 
 	public DefaultSetArbitrary(Arbitrary<T> elementArbitrary) {
@@ -71,7 +73,7 @@ public class DefaultSetArbitrary<T> extends MultivalueArbitraryBase<T, Set<T>> i
 	public <U> Arbitrary<Set<U>> mapEach(BiFunction<Set<T>, T, U> mapper) {
 		return this.map(elements -> elements.stream()
 											.map(e -> mapper.apply(elements, e))
-											.collect(Collectors.toSet()));
+											.collect(toLinkedHashSet()));
 	}
 
 	// TODO: Remove duplication with DefaultListArbitrary.flatMapEach()

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
@@ -10,8 +10,7 @@ import net.jqwik.engine.properties.*;
 import net.jqwik.engine.properties.arbitraries.exhaustive.*;
 import net.jqwik.engine.properties.arbitraries.randomized.*;
 import net.jqwik.engine.properties.shrinking.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 public class DefaultSetArbitrary<T> extends MultivalueArbitraryBase<T, Set<T>> implements SetArbitrary<T> {
 
@@ -73,7 +72,7 @@ public class DefaultSetArbitrary<T> extends MultivalueArbitraryBase<T, Set<T>> i
 	public <U> Arbitrary<Set<U>> mapEach(BiFunction<Set<T>, T, U> mapper) {
 		return this.map(elements -> elements.stream()
 											.map(e -> mapper.apply(elements, e))
-											.collect(toLinkedHashSet()));
+											.collect(JqwikCollectors.toLinkedHashSet()));
 	}
 
 	// TODO: Remove duplication with DefaultListArbitrary.flatMapEach()

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultSetArbitrary.java
@@ -84,7 +84,7 @@ public class DefaultSetArbitrary<T> extends MultivalueArbitraryBase<T, Set<T>> i
 				elements.stream()
 						.map(e -> flatMapper.apply(elements, e))
 						.collect(Collectors.toList());
-			return Combinators.combine(arbitraries).as(HashSet::new);
+			return Combinators.combine(arbitraries).as(LinkedHashSet::new);
 		});
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitrary.java
@@ -16,7 +16,7 @@ public class DefaultStringArbitrary extends TypedCloneable implements StringArbi
 
 	private int minLength = 0;
 	private int maxLength = RandomGenerators.DEFAULT_COLLECTION_SIZE;
-	private Set<Character> excludedChars = new HashSet<>();
+	private Set<Character> excludedChars = new LinkedHashSet<>();
 	private RandomDistribution lengthDistribution = null;
 	private double repeatChars = 0.0;
 

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitrary.java
@@ -185,7 +185,7 @@ public class DefaultStringArbitrary extends TypedCloneable implements StringArbi
 	@Override
 	public StringArbitrary excludeChars(char... charsToExclude) {
 		DefaultStringArbitrary clone = typedClone();
-		Set<Character> excludedChars = new HashSet<>(this.excludedChars);
+		Set<Character> excludedChars = new LinkedHashSet<>(this.excludedChars);
 		for (char c : charsToExclude) {
 			excludedChars.add(c);
 		}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultTraverseArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultTraverseArbitrary.java
@@ -25,7 +25,7 @@ public class DefaultTraverseArbitrary<T> extends ArbitraryDecorator<T> implement
 	private boolean enableRecursion = false;
 
 	public DefaultTraverseArbitrary(Class<T> targetType, Traverser traverser) {
-		this(targetType, traverser, new HashMap<>());
+		this(targetType, traverser, new LinkedHashMap<>());
 	}
 
 	private DefaultTraverseArbitrary(Class<T> targetType, Traverser traverser, Map<TypeUsage, Arbitrary<Object>> arbitrariesCache) {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultTypeArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultTypeArbitrary.java
@@ -15,9 +15,9 @@ import static org.junit.platform.commons.support.ModifierSupport.*;
 public class DefaultTypeArbitrary<T> extends ArbitraryDecorator<T> implements TypeArbitrary<T> {
 
 	private final Class<T> targetType;
-	private final Set<Executable> explicitCreators = new HashSet<>();
-	private final Set<Predicate<? super Constructor<?>>> constructorFilters = new HashSet<>();
-	private final Set<Predicate<Method>> factoryMethodFilters = new HashSet<>();
+	private final Set<Executable> explicitCreators = new LinkedHashSet<>();
+	private final Set<Predicate<? super Constructor<?>>> constructorFilters = new LinkedHashSet<>();
+	private final Set<Predicate<Method>> factoryMethodFilters = new LinkedHashSet<>();
 	private boolean defaultsSet = true;
 
 	private TraverseArbitrary<T> traverseArbitrary;
@@ -137,7 +137,7 @@ public class DefaultTypeArbitrary<T> extends ArbitraryDecorator<T> implements Ty
 
 		@Override
 		public Set<Executable> findCreators(TypeUsage target) {
-			Set<Executable> creators = new HashSet<>();
+			Set<Executable> creators = new LinkedHashSet<>();
 			if (target.isOfType(targetType)) {
 				creators.addAll(explicitCreators);
 			}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/LazyOfArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/LazyOfArbitrary.java
@@ -159,7 +159,7 @@ public class LazyOfArbitrary<T> implements Arbitrary<T> {
 
 	private Stream<Shrinkable<T>> shrinkToAlternatives(Shrinkable<T> current, int genSize, long seed, Set<Integer> usedIndexes) {
 		ShrinkingDistance distance = current.distance();
-		Set<Integer> newUsedIndexes = new HashSet<>(usedIndexes);
+		Set<Integer> newUsedIndexes = new LinkedHashSet<>(usedIndexes);
 		return IntStream
 					   .range(0, suppliers.size())
 					   .filter(index -> !usedIndexes.contains(index))
@@ -173,7 +173,7 @@ public class LazyOfArbitrary<T> implements Arbitrary<T> {
 	@SuppressWarnings("unused")
 	private Stream<Shrinkable<T>> shrinkToAlternativesAndGrow(Shrinkable<T> current, int genSize, long seed, Set<Integer> usedIndexes) {
 		ShrinkingDistance distance = current.distance();
-		Set<Integer> newUsedIndexes = new HashSet<>(usedIndexes);
+		Set<Integer> newUsedIndexes = new LinkedHashSet<>(usedIndexes);
 		return IntStream
 					   .range(0, suppliers.size())
 					   .filter(index -> !usedIndexes.contains(index))

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/LazyOfArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/LazyOfArbitrary.java
@@ -12,14 +12,16 @@ import net.jqwik.engine.execution.lifecycle.*;
 import net.jqwik.engine.properties.shrinking.*;
 import net.jqwik.engine.support.*;
 
+import static net.jqwik.api.lifecycle.Lifespan.*;
+
 public class LazyOfArbitrary<T> implements Arbitrary<T> {
 
 	// Cached arbitraries only have to survive one property
 	private static Store<Map<Integer, LazyOfArbitrary<?>>> arbitrariesStore() {
 		try {
-			return Store.getOrCreate(Tuple.of(LazyOfShrinkable.class, "arbitraries"), Lifespan.PROPERTY, HashMap::new);
+			return Store.getOrCreate(Tuple.of(LazyOfShrinkable.class, "arbitraries"), PROPERTY, LinkedHashMap::new);
 		} catch (OutsideJqwikException outsideJqwikException) {
-			return Store.free(HashMap::new);
+			return Store.free(LinkedHashMap::new);
 		}
 	}
 
@@ -39,9 +41,9 @@ public class LazyOfArbitrary<T> implements Arbitrary<T> {
 
 	private Store<Map<Integer, RandomGenerator<T>>> createGeneratorsStore() {
 		try {
-			return Store.getOrCreate(Tuple.of(this, "generators"), Lifespan.TRY, HashMap::new);
+			return Store.getOrCreate(Tuple.of(this, "generators"), TRY, LinkedHashMap::new);
 		} catch (OutsideJqwikException outsideJqwikException) {
-			return Store.free(HashMap::new);
+			return Store.free(LinkedHashMap::new);
 		}
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/LazyOfArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/LazyOfArbitrary.java
@@ -89,7 +89,7 @@ public class LazyOfArbitrary<T> implements Arbitrary<T> {
 	}
 
 	private void pushGeneratedLevel() {
-		generatedParts.addFirst(new HashSet<>());
+		generatedParts.addFirst(new LinkedHashSet<>());
 	}
 
 	private void popGeneratedLevel() {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/MultivalueArbitraryBase.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/MultivalueArbitraryBase.java
@@ -19,7 +19,7 @@ abstract class MultivalueArbitraryBase<T, U> extends TypedCloneable implements S
 
 	protected int minSize = 0;
 	protected int maxSize = RandomGenerators.DEFAULT_COLLECTION_SIZE;
-	protected Set<FeatureExtractor<T>> uniquenessExtractors = new HashSet<>();
+	protected Set<FeatureExtractor<T>> uniquenessExtractors = new LinkedHashSet<>();
 	protected RandomDistribution sizeDistribution = null;
 
 	protected MultivalueArbitraryBase(Arbitrary<T> elementArbitrary) {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/MultivalueArbitraryBase.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/MultivalueArbitraryBase.java
@@ -79,7 +79,7 @@ abstract class MultivalueArbitraryBase<T, U> extends TypedCloneable implements S
 
 	protected StreamableArbitrary<T, U> uniqueElements(FeatureExtractor<T> by) {
 		MultivalueArbitraryBase<T, U> clone = typedClone();
-		clone.uniquenessExtractors = new HashSet<>(uniquenessExtractors);
+		clone.uniquenessExtractors = new LinkedHashSet<>(uniquenessExtractors);
 		clone.uniquenessExtractors.add(by);
 		return clone;
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/ContainerGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/ContainerGenerator.java
@@ -62,7 +62,7 @@ class ContainerGenerator<T, C> implements RandomGenerator<C> {
 		int sizeToShuffleIfExceeded = Integer.MAX_VALUE;
 
 		boolean canUseSetForValues = uniquenessExtractors.isEmpty() || uniquenessExtractors.contains(FeatureExtractor.identity());
-		Collection<T> existingValues = canUseSetForValues ? new HashSet<>() : new ArrayList<>();
+		Collection<T> existingValues = canUseSetForValues ? new LinkedHashSet<>() : new ArrayList<>();
 
 		while (listOfShrinkables.size() < listSize) {
 			try {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/RandomGenerators.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/RandomGenerators.java
@@ -134,7 +134,7 @@ public class RandomGenerators {
 			int minSize, int maxSize, int genSize, RandomDistribution sizeDistribution,
 			Set<FeatureExtractor<T>> uniquenessExtractors
 	) {
-		Set<FeatureExtractor<T>> extractors = new HashSet<>(uniquenessExtractors);
+		Set<FeatureExtractor<T>> extractors = new LinkedHashSet<>(uniquenessExtractors);
 		extractors.add(FeatureExtractor.identity());
 		Function<List<Shrinkable<T>>, Shrinkable<Set<T>>> createShrinkable =
 			elements -> new ShrinkableSet<T>(elements, minSize, maxSize, uniquenessExtractors);

--- a/engine/src/main/java/net/jqwik/engine/properties/configurators/UniqueElementsConfigurator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/configurators/UniqueElementsConfigurator.java
@@ -11,8 +11,6 @@ import net.jqwik.api.constraints.*;
 import net.jqwik.api.providers.*;
 import net.jqwik.engine.support.*;
 
-import static net.jqwik.engine.support.JqwikCollectors.*;
-
 @SuppressWarnings("unchecked")
 public class UniqueElementsConfigurator implements ArbitraryConfigurator {
 
@@ -73,7 +71,7 @@ public class UniqueElementsConfigurator implements ArbitraryConfigurator {
 	}
 
 	private boolean isUnique(Collection<?> list, Function<Object, Object> extractor) {
-		Set<Object> set = list.stream().map(extractor).collect(toLinkedHashSet());
+		Set<Object> set = list.stream().map(extractor).collect(JqwikCollectors.toLinkedHashSet());
 		return set.size() == list.size();
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/configurators/UniqueElementsConfigurator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/configurators/UniqueElementsConfigurator.java
@@ -11,6 +11,8 @@ import net.jqwik.api.constraints.*;
 import net.jqwik.api.providers.*;
 import net.jqwik.engine.support.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 @SuppressWarnings("unchecked")
 public class UniqueElementsConfigurator implements ArbitraryConfigurator {
 
@@ -71,7 +73,7 @@ public class UniqueElementsConfigurator implements ArbitraryConfigurator {
 	}
 
 	private boolean isUnique(Collection<?> list, Function<Object, Object> extractor) {
-		Set<Object> set = list.stream().map(extractor).collect(Collectors.toSet());
+		Set<Object> set = list.stream().map(extractor).collect(toLinkedHashSet());
 		return set.size() == list.size();
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/AbstractSampleShrinker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/AbstractSampleShrinker.java
@@ -104,7 +104,7 @@ abstract class AbstractSampleShrinker {
 
 		PriorityQueue<Tuple3<List<Object>, List<Shrinkable<Object>>, TryExecutionResult>> prioritizedResults = new PriorityQueue<>(resultComparator);
 
-		Set<Tuple3<List<Object>, List<Shrinkable<Object>>, TryExecutionResult>> removedResults = new HashSet<>();
+		Set<Tuple3<List<Object>, List<Shrinkable<Object>>, TryExecutionResult>> removedResults = new LinkedHashSet<>();
 
 		void push(Tuple3<List<Object>, List<Shrinkable<Object>>, TryExecutionResult> result) {
 			if (removedResults.contains(result)) {

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/AggressiveSizeOfListShrinker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/AggressiveSizeOfListShrinker.java
@@ -25,7 +25,7 @@ public class AggressiveSizeOfListShrinker<T> {
 	}
 
 	public Stream<List<T>> cutsToMinsize(List<T> toShrink) {
-		Set<List<T>> lists = new HashSet<>();
+		Set<List<T>> lists = new LinkedHashSet<>();
 		appendLeftCut(toShrink, lists, minSize);
 		appendRightCut(toShrink, lists, minSize);
 		return lists.stream();
@@ -35,7 +35,7 @@ public class AggressiveSizeOfListShrinker<T> {
 		if (toShrink.size() <= minSize + 1) {
 			return Stream.empty();
 		}
-		Set<List<T>> lists = new HashSet<>();
+		Set<List<T>> lists = new LinkedHashSet<>();
 		appendLeftCut(toShrink, lists, minSize + 1);
 		appendRightCut(toShrink, lists, minSize + 1);
 		return lists.stream();
@@ -46,7 +46,7 @@ public class AggressiveSizeOfListShrinker<T> {
 		if (halfSize < minSize) {
 			return Stream.empty();
 		}
-		Set<List<T>> lists = new HashSet<>();
+		Set<List<T>> lists = new LinkedHashSet<>();
 		appendLeftCut(toShrink, lists, halfSize);
 		appendRightCut(toShrink, lists, toShrink.size() - halfSize);
 		return lists.stream();

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/BigIntegerShrinker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/BigIntegerShrinker.java
@@ -13,7 +13,7 @@ public class BigIntegerShrinker {
 	}
 
 	public Stream<BigInteger> shrink(BigInteger value) {
-		Set<BigInteger> candidates = new HashSet<>();
+		Set<BigInteger> candidates = new LinkedHashSet<>();
 		BigInteger lower = shrinkingTarget.min(value);
 		BigInteger higher = shrinkingTarget.max(value);
 		addFibbonaci(candidates, lower, BigInteger.valueOf(0), BigInteger.valueOf(1), higher);

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/ShrinkableSet.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/ShrinkableSet.java
@@ -5,8 +5,7 @@ import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.engine.properties.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 public class ShrinkableSet<E> extends ShrinkableContainer<Set<E>, E> {
 
@@ -30,7 +29,7 @@ public class ShrinkableSet<E> extends ShrinkableContainer<Set<E>, E> {
 
 	@Override
 	Collector<E, ?, Set<E>> containerCollector() {
-		return toLinkedHashSet();
+		return JqwikCollectors.toLinkedHashSet();
 	}
 
 	@Override

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/ShrinkableSet.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/ShrinkableSet.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.engine.properties.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class ShrinkableSet<E> extends ShrinkableContainer<Set<E>, E> {
 
 	public ShrinkableSet(Collection<Shrinkable<E>> elements, int minSize, int maxSize, Collection<FeatureExtractor<E>> uniquenessExtractors) {
@@ -28,7 +30,7 @@ public class ShrinkableSet<E> extends ShrinkableContainer<Set<E>, E> {
 
 	@Override
 	Collector<E, ?, Set<E>> containerCollector() {
-		return Collectors.toSet();
+		return toLinkedHashSet();
 	}
 
 	@Override

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/ShrinkingAlgorithm.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/ShrinkingAlgorithm.java
@@ -8,7 +8,7 @@ import net.jqwik.api.lifecycle.*;
 
 class ShrinkingAlgorithm {
 
-	private final Map<List<Object>, TryExecutionResult> falsificationCache = new HashMap<>();
+	private final Map<List<Object>, TryExecutionResult> falsificationCache = new LinkedHashMap<>();
 	private final FalsifiedSample originalSample;
 	private final Consumer<FalsifiedSample> sampleShrunkConsumer;
 	private final Consumer<FalsifiedSample> shrinkAttemptConsumer;

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/SizeOfListShrinker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/SizeOfListShrinker.java
@@ -31,7 +31,7 @@ public class SizeOfListShrinker<T> {
 	}
 
 	public Stream<List<T>> cuts(List<T> toShrink) {
-		Set<List<T>> lists = new HashSet<>();
+		Set<List<T>> lists = new LinkedHashSet<>();
 		appendRightCuts(toShrink, lists);
 		appendLeftCuts(toShrink, lists);
 		return lists.stream();

--- a/engine/src/main/java/net/jqwik/engine/properties/state/ShrinkableChainShrinker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/state/ShrinkableChainShrinker.java
@@ -174,7 +174,7 @@ class ShrinkableChainShrinker<T> {
 	}
 
 	private Stream<List<ShrinkableChainIteration<T>>> shrinkToAllSubLists(List<ShrinkableChainIteration<T>> iterations) {
-		Set<List<ShrinkableChainIteration<T>>> setOfSequences = new HashSet<>();
+		Set<List<ShrinkableChainIteration<T>>> setOfSequences = new LinkedHashSet<>();
 		for (int i = 0; i < iterations.size(); i++) {
 			if (!isUnshrinkableEndOfChain(iterations.get(i))) {
 				ArrayList<ShrinkableChainIteration<T>> newCandidate = new ArrayList<>(iterations);

--- a/engine/src/main/java/net/jqwik/engine/properties/stateful/ComprehensiveSizeOfListShrinker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/stateful/ComprehensiveSizeOfListShrinker.java
@@ -9,7 +9,7 @@ class ComprehensiveSizeOfListShrinker {
 		if (toShrink.size() <= minSize) {
 			return Stream.empty();
 		}
-		Set<List<T>> setOfSequences = new HashSet<>();
+		Set<List<T>> setOfSequences = new LinkedHashSet<>();
 		for (int i = 0; i < toShrink.size(); i++) {
 			ArrayList<T> newCandidate = new ArrayList<>(toShrink);
 			newCandidate.remove(i);

--- a/engine/src/main/java/net/jqwik/engine/providers/AbstractCollectionArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/AbstractCollectionArbitraryProvider.java
@@ -1,12 +1,10 @@
 package net.jqwik.engine.providers;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 abstract class AbstractCollectionArbitraryProvider implements ArbitraryProvider {
 
@@ -23,7 +21,7 @@ abstract class AbstractCollectionArbitraryProvider implements ArbitraryProvider 
 		Set<Arbitrary<?>> elementArbitraries = subtypeProvider.apply(elementType);
 		return elementArbitraries.stream()
 								 .map(this::create)
-								 .collect(toLinkedHashSet());
+								 .collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	protected abstract Arbitrary<?> create(Arbitrary<?> innerArbitrary);

--- a/engine/src/main/java/net/jqwik/engine/providers/AbstractCollectionArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/AbstractCollectionArbitraryProvider.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 abstract class AbstractCollectionArbitraryProvider implements ArbitraryProvider {
 
 	@Override
@@ -21,7 +23,7 @@ abstract class AbstractCollectionArbitraryProvider implements ArbitraryProvider 
 		Set<Arbitrary<?>> elementArbitraries = subtypeProvider.apply(elementType);
 		return elementArbitraries.stream()
 								 .map(this::create)
-								 .collect(Collectors.toSet());
+								 .collect(toLinkedHashSet());
 	}
 
 	protected abstract Arbitrary<?> create(Arbitrary<?> innerArbitrary);

--- a/engine/src/main/java/net/jqwik/engine/providers/ArbitraryArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/ArbitraryArbitraryProvider.java
@@ -1,12 +1,10 @@
 package net.jqwik.engine.providers;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 public class ArbitraryArbitraryProvider implements ArbitraryProvider {
 	@Override
@@ -19,6 +17,6 @@ public class ArbitraryArbitraryProvider implements ArbitraryProvider {
 		TypeUsage innerType = targetType.getTypeArguments().get(0);
 		return subtypeProvider.apply(innerType).stream()
 							  .map(Arbitraries::just)
-							  .collect(toLinkedHashSet());
+							  .collect(JqwikCollectors.toLinkedHashSet());
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/ArbitraryArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/ArbitraryArbitraryProvider.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class ArbitraryArbitraryProvider implements ArbitraryProvider {
 	@Override
 	public boolean canProvideFor(TypeUsage targetType) {
@@ -17,6 +19,6 @@ public class ArbitraryArbitraryProvider implements ArbitraryProvider {
 		TypeUsage innerType = targetType.getTypeArguments().get(0);
 		return subtypeProvider.apply(innerType).stream()
 							  .map(Arbitraries::just)
-							  .collect(Collectors.toSet());
+							  .collect(toLinkedHashSet());
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/ArrayArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/ArrayArbitraryProvider.java
@@ -6,6 +6,7 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 import net.jqwik.engine.properties.arbitraries.*;
+import net.jqwik.engine.support.*;
 
 public class ArrayArbitraryProvider implements ArbitraryProvider {
 	@Override
@@ -27,7 +28,7 @@ public class ArrayArbitraryProvider implements ArbitraryProvider {
 					return DefaultArrayArbitrary.forComponentType(elementArbitrary, componentClass);
 				}
 			})
-			.collect(Collectors.toSet());
+			.collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	private Class<?> upperboundsSupertype(TypeUsage componentType) {

--- a/engine/src/main/java/net/jqwik/engine/providers/EntryArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/EntryArbitraryProvider.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class EntryArbitraryProvider implements ArbitraryProvider {
 	@Override
 	public boolean canProvideFor(TypeUsage targetType) {
@@ -24,7 +26,7 @@ public class EntryArbitraryProvider implements ArbitraryProvider {
 				Arbitrary<?> valueArbitrary = arbitraries.get(1);
 				return Arbitraries.entries(keyArbitrary, valueArbitrary);
 			})
-			.collect(Collectors.toSet());
+			.collect(toLinkedHashSet());
 
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/EntryArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/EntryArbitraryProvider.java
@@ -1,12 +1,10 @@
 package net.jqwik.engine.providers;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 public class EntryArbitraryProvider implements ArbitraryProvider {
 	@Override
@@ -26,7 +24,7 @@ public class EntryArbitraryProvider implements ArbitraryProvider {
 				Arbitrary<?> valueArbitrary = arbitraries.get(1);
 				return Arbitraries.entries(keyArbitrary, valueArbitrary);
 			})
-			.collect(toLinkedHashSet());
+			.collect(JqwikCollectors.toLinkedHashSet());
 
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/FunctionArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/FunctionArbitraryProvider.java
@@ -2,14 +2,11 @@ package net.jqwik.engine.providers;
 
 import java.lang.reflect.*;
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 import net.jqwik.engine.support.*;
 import net.jqwik.engine.support.types.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 
 public class FunctionArbitraryProvider implements ArbitraryProvider {
 
@@ -40,7 +37,7 @@ public class FunctionArbitraryProvider implements ArbitraryProvider {
 					   Arbitrary<?> resultArbitrary = arbitraries.get(0);
 					   return Functions.function(functionalType).returning(resultArbitrary);
 				   })
-				   .collect(toLinkedHashSet());
+				   .collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	private TypeUsage getReturnType(TypeUsage targetType) {

--- a/engine/src/main/java/net/jqwik/engine/providers/FunctionArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/FunctionArbitraryProvider.java
@@ -9,6 +9,8 @@ import net.jqwik.api.providers.*;
 import net.jqwik.engine.support.*;
 import net.jqwik.engine.support.types.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class FunctionArbitraryProvider implements ArbitraryProvider {
 
 	private static final Class<?>[] EXCLUDE_TYPES =
@@ -38,7 +40,7 @@ public class FunctionArbitraryProvider implements ArbitraryProvider {
 					   Arbitrary<?> resultArbitrary = arbitraries.get(0);
 					   return Functions.function(functionalType).returning(resultArbitrary);
 				   })
-				   .collect(Collectors.toSet());
+				   .collect(toLinkedHashSet());
 	}
 
 	private TypeUsage getReturnType(TypeUsage targetType) {

--- a/engine/src/main/java/net/jqwik/engine/providers/HashMapArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/HashMapArbitraryProvider.java
@@ -1,12 +1,10 @@
 package net.jqwik.engine.providers;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 public class HashMapArbitraryProvider implements ArbitraryProvider {
 	@Override
@@ -26,6 +24,6 @@ public class HashMapArbitraryProvider implements ArbitraryProvider {
 				Arbitrary<?> valueArbitrary = arbitraries.get(1);
 				return Arbitraries.maps(keyArbitrary, valueArbitrary);
 			})
-			.collect(toLinkedHashSet());
+			.collect(JqwikCollectors.toLinkedHashSet());
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/HashMapArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/HashMapArbitraryProvider.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class HashMapArbitraryProvider implements ArbitraryProvider {
 	@Override
 	public boolean canProvideFor(TypeUsage targetType) {
@@ -24,6 +26,6 @@ public class HashMapArbitraryProvider implements ArbitraryProvider {
 				Arbitrary<?> valueArbitrary = arbitraries.get(1);
 				return Arbitraries.maps(keyArbitrary, valueArbitrary);
 			})
-			.collect(Collectors.toSet());
+			.collect(toLinkedHashSet());
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/NullableArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/NullableArbitraryProvider.java
@@ -7,6 +7,8 @@ import net.jqwik.api.*;
 import net.jqwik.api.constraints.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class NullableArbitraryProvider implements ArbitraryProvider {
 	@Override
 	public boolean canProvideFor(TypeUsage targetType) {
@@ -22,7 +24,7 @@ public class NullableArbitraryProvider implements ArbitraryProvider {
 		Set<Arbitrary<?>> rawArbitraries = subtypeProvider.apply(nonNullType);
 		return rawArbitraries.stream()
 				   .map(a -> a.injectNull(0.05))
-				   .collect(Collectors.toSet());
+				   .collect(toLinkedHashSet());
 	}
 
 	@Override

--- a/engine/src/main/java/net/jqwik/engine/providers/NullableArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/NullableArbitraryProvider.java
@@ -1,13 +1,11 @@
 package net.jqwik.engine.providers;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.constraints.*;
 import net.jqwik.api.providers.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 public class NullableArbitraryProvider implements ArbitraryProvider {
 	@Override
@@ -24,7 +22,7 @@ public class NullableArbitraryProvider implements ArbitraryProvider {
 		Set<Arbitrary<?>> rawArbitraries = subtypeProvider.apply(nonNullType);
 		return rawArbitraries.stream()
 				   .map(a -> a.injectNull(0.05))
-				   .collect(toLinkedHashSet());
+				   .collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	@Override

--- a/engine/src/main/java/net/jqwik/engine/providers/OptionalArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/OptionalArbitraryProvider.java
@@ -1,12 +1,10 @@
 package net.jqwik.engine.providers;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+import net.jqwik.engine.support.*;
 
 public class OptionalArbitraryProvider implements ArbitraryProvider {
 	@Override
@@ -19,6 +17,6 @@ public class OptionalArbitraryProvider implements ArbitraryProvider {
 		TypeUsage innerType = targetType.getTypeArguments().get(0);
 		return subtypeProvider.apply(innerType).stream() //
 							  .map(Arbitrary::optional)
-							  .collect(toLinkedHashSet());
+							  .collect(JqwikCollectors.toLinkedHashSet());
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/providers/OptionalArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/OptionalArbitraryProvider.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
+
 public class OptionalArbitraryProvider implements ArbitraryProvider {
 	@Override
 	public boolean canProvideFor(TypeUsage targetType) {
@@ -17,6 +19,6 @@ public class OptionalArbitraryProvider implements ArbitraryProvider {
 		TypeUsage innerType = targetType.getTypeArguments().get(0);
 		return subtypeProvider.apply(innerType).stream() //
 							  .map(Arbitrary::optional)
-							  .collect(Collectors.toSet());
+							  .collect(toLinkedHashSet());
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/recording/TestRunData.java
+++ b/engine/src/main/java/net/jqwik/engine/recording/TestRunData.java
@@ -16,7 +16,7 @@ public class TestRunData {
 	}
 
 	public TestRunData() {
-		this(new HashSet<>());
+		this(new LinkedHashSet<>());
 	}
 
 	public void add(TestRun testRun) {

--- a/engine/src/main/java/net/jqwik/engine/support/Combinatorics.java
+++ b/engine/src/main/java/net/jqwik/engine/support/Combinatorics.java
@@ -26,7 +26,7 @@ public class Combinatorics {
 
 	@SuppressWarnings("unchecked")
 	private static <T> Iterator<Set<T>> emptySetSingleton() {
-		return asList((Set<T>) new HashSet<>()).iterator();
+		return asList((Set<T>) new LinkedHashSet<>()).iterator();
 	}
 
 	public static <T> Iterator<List<T>> listCombinations(Iterable<T> elementIterable, int minSize, int maxSize) {

--- a/engine/src/main/java/net/jqwik/engine/support/GenericsClassContext.java
+++ b/engine/src/main/java/net/jqwik/engine/support/GenericsClassContext.java
@@ -22,7 +22,7 @@ public class GenericsClassContext {
 	};
 
 	private final TypeUsage contextType;
-	private final Map<LookupTypeVariable, TypeResolution> resolutions = new HashMap<>();
+	private final Map<LookupTypeVariable, TypeResolution> resolutions = new LinkedHashMap<>();
 
 	GenericsClassContext(TypeUsage contextType) {
 		this.contextType = contextType;

--- a/engine/src/main/java/net/jqwik/engine/support/GenericsSupport.java
+++ b/engine/src/main/java/net/jqwik/engine/support/GenericsSupport.java
@@ -7,7 +7,7 @@ import net.jqwik.api.providers.*;
 
 public class GenericsSupport {
 
-	private static Map<TypeUsage, GenericsClassContext> contextsCache = new HashMap<>();
+	private static Map<TypeUsage, GenericsClassContext> contextsCache = new LinkedHashMap<>();
 
 	/**
 	 * Return a context object which can resolve generic types for a given {@code contextClass}.

--- a/engine/src/main/java/net/jqwik/engine/support/JqwikCollectors.java
+++ b/engine/src/main/java/net/jqwik/engine/support/JqwikCollectors.java
@@ -1,0 +1,10 @@
+package net.jqwik.engine.support;
+
+import java.util.*;
+import java.util.stream.*;
+
+public class JqwikCollectors {
+	public static <T> Collector<T, ?, Set<T>> toLinkedHashSet() {
+		return Collectors.toCollection(LinkedHashSet::new);
+	}
+}

--- a/engine/src/main/java/net/jqwik/engine/support/JqwikReflectionSupport.java
+++ b/engine/src/main/java/net/jqwik/engine/support/JqwikReflectionSupport.java
@@ -14,7 +14,6 @@ import net.jqwik.api.providers.*;
 
 import static java.util.stream.Collectors.*;
 
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 import static net.jqwik.engine.support.OverriddenMethodAnnotationSupport.*;
 
 public class JqwikReflectionSupport {
@@ -173,7 +172,7 @@ public class JqwikReflectionSupport {
 		String classpath = System.getProperty("java.class.path");
 		return Arrays.stream(classpath.split(File.pathSeparator))
 					 .map(Paths::get).filter(Files::isDirectory)
-					 .collect(toLinkedHashSet());
+					 .collect(JqwikCollectors.toLinkedHashSet());
 	}
 
 	public static List<MethodParameter> getMethodParameters(Executable method, Class<?> containerClass) {

--- a/engine/src/main/java/net/jqwik/engine/support/JqwikReflectionSupport.java
+++ b/engine/src/main/java/net/jqwik/engine/support/JqwikReflectionSupport.java
@@ -14,6 +14,7 @@ import net.jqwik.api.providers.*;
 
 import static java.util.stream.Collectors.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 import static net.jqwik.engine.support.OverriddenMethodAnnotationSupport.*;
 
 public class JqwikReflectionSupport {
@@ -172,7 +173,7 @@ public class JqwikReflectionSupport {
 		String classpath = System.getProperty("java.class.path");
 		return Arrays.stream(classpath.split(File.pathSeparator))
 					 .map(Paths::get).filter(Files::isDirectory)
-					 .collect(toSet());
+					 .collect(toLinkedHashSet());
 	}
 
 	public static List<MethodParameter> getMethodParameters(Executable method, Class<?> containerClass) {

--- a/engine/src/main/java/net/jqwik/engine/support/combinatorics/SetIterator.java
+++ b/engine/src/main/java/net/jqwik/engine/support/combinatorics/SetIterator.java
@@ -5,7 +5,7 @@ import java.util.*;
 public class SetIterator<T> implements Iterator<Set<T>> {
 
 	private final Iterator<List<T>> combinedListIterator;
-	private final Set<Set<T>> generatedSets = new HashSet<>();
+	private final Set<Set<T>> generatedSets = new LinkedHashSet<>();
 	private final int setSize;
 	private Set<T> next;
 

--- a/engine/src/main/java/net/jqwik/engine/support/combinatorics/SetIterator.java
+++ b/engine/src/main/java/net/jqwik/engine/support/combinatorics/SetIterator.java
@@ -21,7 +21,7 @@ public class SetIterator<T> implements Iterator<Set<T>> {
 
 	private Set<T> findNext() {
 		while (combinedListIterator.hasNext()) {
-			HashSet<T> candidate = new HashSet<>(combinedListIterator.next());
+			HashSet<T> candidate = new LinkedHashSet<>(combinedListIterator.next());
 			if (candidate.size() != setSize || generatedSets.contains(candidate)) {
 				continue;
 			}

--- a/engine/src/main/java/net/jqwik/engine/support/types/TypeUsageImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/support/types/TypeUsageImpl.java
@@ -307,7 +307,7 @@ public class TypeUsageImpl implements TypeUsage, Cloneable {
 
 	private final List<TypeUsage> upperBounds = new ArrayList<>();
 	private final List<TypeUsage> lowerBounds = new ArrayList<>();
-	private HashMap<String, Object> metaInfo = new HashMap<>();
+	private HashMap<String, Object> metaInfo = new LinkedHashMap<>();
 	private boolean isNullable = false;
 
 	public TypeUsageImpl(

--- a/engine/src/main/java/net/jqwik/engine/support/types/TypeUsageImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/support/types/TypeUsageImpl.java
@@ -716,7 +716,7 @@ public class TypeUsageImpl implements TypeUsage, Cloneable {
 	@Override
 	public TypeUsage withMetaInfo(String key, Object value) {
 		return cloneWith(t -> {
-			t.metaInfo = new HashMap<>(metaInfo);
+			t.metaInfo = new LinkedHashMap<>(metaInfo);
 			t.metaInfo.put(key, value);
 		});
 	}

--- a/engine/src/main/java/net/jqwik/engine/support/types/TypeUsageToString.java
+++ b/engine/src/main/java/net/jqwik/engine/support/types/TypeUsageToString.java
@@ -9,7 +9,7 @@ import net.jqwik.api.providers.*;
 class TypeUsageToString {
 
 	public static String toString(TypeUsage self) {
-		return toString(self, new HashSet<>());
+		return toString(self, new LinkedHashSet<>());
 	}
 
 	private static String toString(TypeUsage self, Set<TypeUsage> touchedTypes) {

--- a/engine/src/test/java/examples/bugs/ExhaustiveGenerationBug.java
+++ b/engine/src/test/java/examples/bugs/ExhaustiveGenerationBug.java
@@ -23,7 +23,7 @@ class ExhaustiveGenerationBug {
 
 	private boolean hasNoDuplicates(List<List<Integer>> matrix) {
 		List<Integer> all = matrix.stream().flatMap(List::stream).collect(Collectors.toList());
-		HashSet<Integer> allSet = new HashSet<>(all);
+		HashSet<Integer> allSet = new LinkedHashSet<>(all);
 		return all.size() == allSet.size();
 	}
 

--- a/engine/src/test/java/examples/bugs/ShrinkingListElementsNotEnough.java
+++ b/engine/src/test/java/examples/bugs/ShrinkingListElementsNotEnough.java
@@ -22,7 +22,7 @@ class ShrinkingListElementsNotEnough {
 	}
 
 	private <T> List<T> reverseWithoutDuplicates(List<T> original) {
-		List<T> clone = new ArrayList<>(new HashSet<>(original));
+		List<T> clone = new ArrayList<>(new LinkedHashSet<>(original));
 		Collections.reverse(clone);
 		return clone;
 	}

--- a/engine/src/test/java/net/jqwik/UseArbitrariesOutsideJqwikTests.java
+++ b/engine/src/test/java/net/jqwik/UseArbitrariesOutsideJqwikTests.java
@@ -79,7 +79,7 @@ class UseArbitrariesOutsideJqwikTests {
 		for (int i = 0; i < 20; i++) {
 
 			List<Integer> listWithDuplicates = intsWithDuplicates.list().ofSize(100).sample();
-			Set<Integer> noMoreDuplicates = new HashSet<>(listWithDuplicates);
+			Set<Integer> noMoreDuplicates = new LinkedHashSet<>(listWithDuplicates);
 
 			if (i < 19) {
 				// Can fail because collections with no duplicates have probability of approx. 5%

--- a/engine/src/test/java/net/jqwik/api/ArbitrariesTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArbitrariesTests.java
@@ -18,6 +18,7 @@ import net.jqwik.engine.support.types.*;
 import net.jqwik.testing.*;
 
 import static java.math.BigInteger.*;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.TestingSupport.*;
@@ -86,7 +87,7 @@ class ArbitrariesTests {
 
 	@Example
 	void ofValueSet(@ForAll Random random) {
-		Set<String> valueSet = new HashSet<>(Arrays.asList("1", "hallo", "test"));
+		Set<String> valueSet = new LinkedHashSet<>(asList("1", "hallo", "test"));
 		Arbitrary<String> stringArbitrary = Arbitraries.of(valueSet);
 		RandomGenerator<String> generator = stringArbitrary.generator(1);
 		checkAllGenerated(generator, random, (String value) -> Arrays.asList("1", "hallo", "test").contains(value));
@@ -120,7 +121,7 @@ class ArbitrariesTests {
 	void ofSupplierSet(@ForAll Random random) {
 		@SuppressWarnings("unchecked")
 		Supplier<List<String>>[] suppliers = new Supplier[]{ArrayList::new, ArrayList::new};
-		Set<Supplier<List<String>>> supplierList = new HashSet<>(Arrays.asList(suppliers));
+		Set<Supplier<List<String>>> supplierList = new LinkedHashSet<>(asList(suppliers));
 		Arbitrary<List<String>> listArbitrary = Arbitraries.ofSuppliers(supplierList);
 		RandomGenerator<List<String>> generator = listArbitrary.generator(1);
 		assertAllGenerated(generator, random, (List<String> value) -> {

--- a/engine/src/test/java/net/jqwik/api/ArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArbitraryTests.java
@@ -486,7 +486,7 @@ class ArbitraryTests {
 
 			RandomGenerator<List<Integer>> generator = arbitrary.generator(1000, false);
 			List<Integer> listWithDuplicates = generator.next(random).value();
-			Set<Integer> noMoreDuplicates = new HashSet<>(listWithDuplicates);
+			Set<Integer> noMoreDuplicates = new LinkedHashSet<>(listWithDuplicates);
 
 			Statistics
 				.label("duplicates > 10%")
@@ -502,7 +502,7 @@ class ArbitraryTests {
 
 			RandomGenerator<List<Integer>> generator = arbitrary.generator(1000, false);
 			List<Integer> listWithDuplicates = generator.next(random).value();
-			Set<Integer> noMoreDuplicates = new HashSet<>(listWithDuplicates);
+			Set<Integer> noMoreDuplicates = new LinkedHashSet<>(listWithDuplicates);
 
 			Statistics
 				.label("duplicates > 40%")
@@ -518,7 +518,7 @@ class ArbitraryTests {
 
 			RandomGenerator<List<Integer>> generator = arbitrary.generator(1000, false);
 			List<Integer> listWithDuplicates = generator.next(random).value();
-			Set<Integer> noMoreDuplicates = new HashSet<>(listWithDuplicates);
+			Set<Integer> noMoreDuplicates = new LinkedHashSet<>(listWithDuplicates);
 			assertThat(noMoreDuplicates).hasSize(1);
 		}
 
@@ -528,7 +528,7 @@ class ArbitraryTests {
 			Arbitrary<Integer> intsWithDuplicates = ints.injectDuplicates(1.0);
 
 			List<Integer> listWithDuplicates = intsWithDuplicates.list().ofSize(50).sample();
-			Set<Integer> noMoreDuplicates = new HashSet<>(listWithDuplicates);
+			Set<Integer> noMoreDuplicates = new LinkedHashSet<>(listWithDuplicates);
 
 			assertThat(noMoreDuplicates).hasSize(1);
 		}

--- a/engine/src/test/java/net/jqwik/api/ArrayArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArrayArbitraryTests.java
@@ -180,7 +180,7 @@ class ArrayArbitraryTests {
 			}
 			return i % modulo;
 		}).collect(Collectors.toList());
-		return new HashSet<>(modulo100).size() == list.size();
+		return new LinkedHashSet<>(modulo100).size() == list.size();
 	}
 
 	@Group

--- a/engine/src/test/java/net/jqwik/api/ExhaustiveGenerationTests.java
+++ b/engine/src/test/java/net/jqwik/api/ExhaustiveGenerationTests.java
@@ -123,7 +123,7 @@ class ExhaustiveGenerationTests {
 	@Example
 	@Label("Arbitrary.flatMap() will freshly generate base values")
 	void flatMapWillFreshlyGenerateBaseValues() {
-		Set<Object> dates = new HashSet<>();
+		Set<Object> dates = new LinkedHashSet<>();
 
 		Optional<ExhaustiveGenerator<Integer>> optionalGenerator =
 			Arbitraries.create(Object::new).flatMap(object -> {

--- a/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
@@ -1,16 +1,14 @@
 package net.jqwik.api;
 
+import java.util.ArrayList;
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.arbitraries.*;
 import net.jqwik.api.constraints.*;
 import net.jqwik.api.statistics.*;
+import net.jqwik.engine.support.*;
 
 import static java.util.Arrays.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
-
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -92,7 +90,7 @@ class IteratorArbitraryTests {
 							 while (iterator.hasNext()) { list.add(iterator.next()); }
 							 return list;
 						 })
-						 .collect(toLinkedHashSet());
+						 .collect(JqwikCollectors.toLinkedHashSet());
 		assertThat(lists).containsExactlyInAnyOrder(
 				Collections.emptyList(),
 				Collections.singletonList(-10),

--- a/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
@@ -8,6 +8,9 @@ import net.jqwik.api.constraints.*;
 import net.jqwik.api.statistics.*;
 
 import static java.util.Arrays.*;
+
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -89,7 +92,7 @@ class IteratorArbitraryTests {
 							 while (iterator.hasNext()) { list.add(iterator.next()); }
 							 return list;
 						 })
-						 .collect(Collectors.toSet());
+						 .collect(toLinkedHashSet());
 		assertThat(lists).containsExactlyInAnyOrder(
 				Collections.emptyList(),
 				Collections.singletonList(-10),

--- a/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
@@ -110,7 +110,7 @@ class IteratorArbitraryTests {
 	}
 
 	private boolean isUniqueModulo(Iterator<Integer> iterator, int modulo) {
-		Set<Integer> moduloSet = new HashSet<>();
+		Set<Integer> moduloSet = new LinkedHashSet<>();
 		int count = 0;
 		while (iterator.hasNext()) {
 			count++;
@@ -214,7 +214,7 @@ class IteratorArbitraryTests {
 	}
 
 	private void assertGeneratedIterator(Shrinkable<Iterator<Integer>> shrinkable) {
-		Set<Integer> set = new HashSet<>();
+		Set<Integer> set = new LinkedHashSet<>();
 		Iterator<Integer> iterator = shrinkable.value();
 		while (iterator.hasNext()) {
 			set.add(iterator.next());

--- a/engine/src/test/java/net/jqwik/api/ListArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/ListArbitraryTests.java
@@ -251,7 +251,7 @@ class ListArbitraryTests {
 			}
 			return i % modulo;
 		}).collect(Collectors.toList());
-		return new HashSet<>(moduloList).size() == list.size();
+		return new LinkedHashSet<>(moduloList).size() == list.size();
 	}
 
 	@Example

--- a/engine/src/test/java/net/jqwik/api/MapArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/MapArbitraryTests.java
@@ -144,7 +144,7 @@ class MapArbitraryTests {
 			}
 			return i % modulo;
 		}).collect(Collectors.toList());
-		return new HashSet<>(moduloList).size() == list.size();
+		return new LinkedHashSet<>(moduloList).size() == list.size();
 	}
 
 	@Group

--- a/engine/src/test/java/net/jqwik/api/MapArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/MapArbitraryTests.java
@@ -223,7 +223,7 @@ class MapArbitraryTests {
 
 		@SafeVarargs
 		private final <T, U> Map<T, U> createMap(Tuple.Tuple2<T, U>... tuples) {
-			HashMap<T, U> result = new HashMap<>();
+			HashMap<T, U> result = new LinkedHashMap<>();
 			for (Tuple.Tuple2<T, U> tuple : tuples) {
 				result.put(tuple.get1(), tuple.get2());
 			}

--- a/engine/src/test/java/net/jqwik/api/SetArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/SetArbitraryTests.java
@@ -137,7 +137,7 @@ class SetArbitraryTests {
 			}
 			return i % modulo;
 		}).collect(Collectors.toList());
-		return new HashSet<>(moduloList).size() == list.size();
+		return new LinkedHashSet<>(moduloList).size() == list.size();
 	}
 
 	@Group
@@ -202,7 +202,7 @@ class SetArbitraryTests {
 		}
 
 		private Set<Integer> asSet(Integer... ints) {
-			return new HashSet<>(asList(ints));
+			return new LinkedHashSet<>(asList(ints));
 		}
 
 		@Example

--- a/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
@@ -104,7 +104,7 @@ class StreamArbitraryTests {
 			}
 			return i % modulo;
 		}).collect(Collectors.toList());
-		return new HashSet<>(moduloList).size() == list.size();
+		return new LinkedHashSet<>(moduloList).size() == list.size();
 	}
 
 

--- a/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
@@ -8,11 +8,9 @@ import net.jqwik.api.constraints.*;
 import net.jqwik.api.edgeCases.*;
 import net.jqwik.api.statistics.*;
 import net.jqwik.engine.properties.arbitraries.*;
+import net.jqwik.engine.support.*;
 
 import static java.util.Arrays.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
-
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -123,7 +121,7 @@ class StreamArbitraryTests {
 			Arbitrary<Integer> ints = Arbitraries.of(-10, 10);
 			Arbitrary<Stream<Integer>> arbitrary = ints.stream();
 			Set<Stream<Integer>> streams = collectEdgeCaseValues(arbitrary.edgeCases());
-			Set<List<Integer>> lists = streams.stream().map(stream -> stream.collect(Collectors.toList())).collect(toLinkedHashSet());
+			Set<List<Integer>> lists = streams.stream().map(stream -> stream.collect(Collectors.toList())).collect(JqwikCollectors.toLinkedHashSet());
 			assertThat(lists).containsExactlyInAnyOrder(
 				Collections.emptyList(),
 				Collections.singletonList(-10),
@@ -247,7 +245,7 @@ class StreamArbitraryTests {
 	}
 
 	private void assertGeneratedStream(Shrinkable<Stream<Integer>> stream) {
-		Set<Integer> set = stream.value().collect(toLinkedHashSet());
+		Set<Integer> set = stream.value().collect(JqwikCollectors.toLinkedHashSet());
 		assertThat(set.size()).isBetween(0, 5);
 		assertThat(set).isSubsetOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 	}

--- a/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
@@ -10,6 +10,9 @@ import net.jqwik.api.statistics.*;
 import net.jqwik.engine.properties.arbitraries.*;
 
 import static java.util.Arrays.*;
+
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -120,7 +123,7 @@ class StreamArbitraryTests {
 			Arbitrary<Integer> ints = Arbitraries.of(-10, 10);
 			Arbitrary<Stream<Integer>> arbitrary = ints.stream();
 			Set<Stream<Integer>> streams = collectEdgeCaseValues(arbitrary.edgeCases());
-			Set<List<Integer>> lists = streams.stream().map(stream -> stream.collect(Collectors.toList())).collect(Collectors.toSet());
+			Set<List<Integer>> lists = streams.stream().map(stream -> stream.collect(Collectors.toList())).collect(toLinkedHashSet());
 			assertThat(lists).containsExactlyInAnyOrder(
 				Collections.emptyList(),
 				Collections.singletonList(-10),
@@ -244,7 +247,7 @@ class StreamArbitraryTests {
 	}
 
 	private void assertGeneratedStream(Shrinkable<Stream<Integer>> stream) {
-		Set<Integer> set = stream.value().collect(Collectors.toSet());
+		Set<Integer> set = stream.value().collect(toLinkedHashSet());
 		assertThat(set.size()).isBetween(0, 5);
 		assertThat(set).isSubsetOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 	}

--- a/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
+++ b/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
@@ -8,6 +8,8 @@ import net.jqwik.api.*;
 
 import static java.util.Arrays.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 @PropertyDefaults(tries = 100)
 @Group
 class UniqueElementsProperties {
@@ -190,7 +192,7 @@ class UniqueElementsProperties {
 	}
 
 	private <T> boolean hasNoDuplicates(Collection<T> collection, Function<T, Object> by) {
-		Set<Object> set = collection.stream().map(by).collect(Collectors.toSet());
+		Set<Object> set = collection.stream().map(by).collect(toLinkedHashSet());
 		return set.size() == collection.size();
 	}
 }

--- a/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
+++ b/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
@@ -81,7 +81,7 @@ class UniqueElementsProperties {
 		}
 
 		private Set<String> asSet(String ... strings) {
-			return new HashSet<>(asList(strings));
+			return new LinkedHashSet<>(asList(strings));
 		}
 
 		private class GetFirstTwoChars implements Function<String, Object> {

--- a/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
+++ b/engine/src/test/java/net/jqwik/api/constraints/UniqueElementsProperties.java
@@ -5,10 +5,9 @@ import java.util.function.*;
 import java.util.stream.*;
 
 import net.jqwik.api.*;
+import net.jqwik.engine.support.*;
 
 import static java.util.Arrays.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
 
 @PropertyDefaults(tries = 100)
 @Group
@@ -192,7 +191,7 @@ class UniqueElementsProperties {
 	}
 
 	private <T> boolean hasNoDuplicates(Collection<T> collection, Function<T, Object> by) {
-		Set<Object> set = collection.stream().map(by).collect(toLinkedHashSet());
+		Set<Object> set = collection.stream().map(by).collect(JqwikCollectors.toLinkedHashSet());
 		return set.size() == collection.size();
 	}
 }

--- a/engine/src/test/java/net/jqwik/api/domains/ContextWithInnerProviderClasses.java
+++ b/engine/src/test/java/net/jqwik/api/domains/ContextWithInnerProviderClasses.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 class ContextWithInnerProviderClasses extends DomainContextBase {
 
 	class MyStringProvider implements ArbitraryProvider {
@@ -30,7 +32,7 @@ class ContextWithInnerProviderClasses extends DomainContextBase {
 		public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
 			TypeUsage innerTarget = targetType.getTypeArgument(0);
 			Set<Arbitrary<?>> innerProviders = subtypeProvider.apply(innerTarget);
-			return innerProviders.stream().map(inner -> inner.list().ofSize(3)).collect(Collectors.toSet());
+			return innerProviders.stream().map(inner -> inner.list().ofSize(3)).collect(toLinkedHashSet());
 		}
 	}
 

--- a/engine/src/test/java/net/jqwik/api/domains/ContextWithInnerProviderClasses.java
+++ b/engine/src/test/java/net/jqwik/api/domains/ContextWithInnerProviderClasses.java
@@ -1,12 +1,10 @@
 package net.jqwik.api.domains;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.providers.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
+import net.jqwik.engine.support.*;
 
 class ContextWithInnerProviderClasses extends DomainContextBase {
 
@@ -32,7 +30,7 @@ class ContextWithInnerProviderClasses extends DomainContextBase {
 		public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
 			TypeUsage innerTarget = targetType.getTypeArgument(0);
 			Set<Arbitrary<?>> innerProviders = subtypeProvider.apply(innerTarget);
-			return innerProviders.stream().map(inner -> inner.list().ofSize(3)).collect(toLinkedHashSet());
+			return innerProviders.stream().map(inner -> inner.list().ofSize(3)).collect(JqwikCollectors.toLinkedHashSet());
 		}
 	}
 

--- a/engine/src/test/java/net/jqwik/api/domains/DomainInitializationTests.java
+++ b/engine/src/test/java/net/jqwik/api/domains/DomainInitializationTests.java
@@ -6,6 +6,8 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.lifecycle.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 import static org.assertj.core.api.Assertions.*;
 
 @Group
@@ -32,7 +34,7 @@ class DomainInitializationTests {
 		List<PropertyLifecycleContext> contexts = DomainWithInitializeMethod.initializedContexts;
 		assertThat(contexts).hasSize(3);
 
-		Set<String> labels = contexts.stream().map(LifecycleContext::label).collect(Collectors.toSet());
+		Set<String> labels = contexts.stream().map(LifecycleContext::label).collect(toLinkedHashSet());
 		assertThat(labels).containsExactlyInAnyOrder("prop1", "prop2", "prop3");
 	}
 

--- a/engine/src/test/java/net/jqwik/api/domains/DomainInitializationTests.java
+++ b/engine/src/test/java/net/jqwik/api/domains/DomainInitializationTests.java
@@ -1,12 +1,10 @@
 package net.jqwik.api.domains;
 
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.lifecycle.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
+import net.jqwik.engine.support.*;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -34,7 +32,7 @@ class DomainInitializationTests {
 		List<PropertyLifecycleContext> contexts = DomainWithInitializeMethod.initializedContexts;
 		assertThat(contexts).hasSize(3);
 
-		Set<String> labels = contexts.stream().map(LifecycleContext::label).collect(toLinkedHashSet());
+		Set<String> labels = contexts.stream().map(LifecycleContext::label).collect(JqwikCollectors.toLinkedHashSet());
 		assertThat(labels).containsExactlyInAnyOrder("prop1", "prop2", "prop3");
 	}
 

--- a/engine/src/test/java/net/jqwik/api/edgeCases/GenericEdgeCasesProperties.java
+++ b/engine/src/test/java/net/jqwik/api/edgeCases/GenericEdgeCasesProperties.java
@@ -1,6 +1,11 @@
 package net.jqwik.api.edgeCases;
 
 import net.jqwik.api.*;
+import net.jqwik.api.constraints.*;
+import net.jqwik.engine.*;
+import net.jqwik.engine.support.*;
+
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -19,4 +24,51 @@ public interface GenericEdgeCasesProperties {
 		assertThat(arbitrary.edgeCases(-42)).hasSize(0);
 	}
 
+	@Property
+	default void mapEachProducesConsistentItemOrder(@ForAll("arbitraries") Arbitrary<?> arbitrary, @ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int size) {
+		Arbitrary<Set<Object>> values = arbitrary.<Object>map(x -> new Object() {
+			@Override
+			public String toString() {
+				return JqwikStringSupport.displayString(x);
+			}
+		}).set().mapEach((set, value) -> value);
+		RandomGenerator<Set<Object>> gen = values.generator(1000, true);
+		for (int i = 0; i < size; i++) {
+			long seed = random.nextLong();
+			assertThat(JqwikStringSupport.displayString(gen.next(SourceOfRandomness.newRandom(seed)).value()))
+				.isEqualTo(JqwikStringSupport.displayString(gen.next(SourceOfRandomness.newRandom(seed)).value()));
+		}
+	}
+
+	@Property
+	default void flatMapEachProducesConsistentItemOrder(@ForAll("arbitraries") Arbitrary<?> arbitrary, @ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int size) {
+		Arbitrary<Set<Object>> values = arbitrary.<Object>map(x -> new Object() {
+			@Override
+			public String toString() {
+				return JqwikStringSupport.displayString(x);
+			}
+		}).set().flatMapEach((set, value) -> Arbitraries.just(value));
+		RandomGenerator<Set<Object>> gen = values.generator(1000, true);
+		for (int i = 0; i < size; i++) {
+			long seed = random.nextLong();
+			assertThat(JqwikStringSupport.displayString(gen.next(SourceOfRandomness.newRandom(seed)).value()))
+				.isEqualTo(JqwikStringSupport.displayString(gen.next(SourceOfRandomness.newRandom(seed)).value()));
+		}
+	}
+
+	@Property
+	default void uniqueElementsProducesConsistentItemOrder(@ForAll("arbitraries") Arbitrary<?> arbitrary, @ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int size) {
+		Arbitrary<Set<Object>> values = arbitrary.<Object>map(x -> new Object() {
+			@Override
+			public String toString() {
+				return JqwikStringSupport.displayString(x);
+			}
+		}).set().uniqueElements(JqwikStringSupport::displayString);
+		RandomGenerator<Set<Object>> gen = values.generator(1000, true);
+		for (int i = 0; i < size; i++) {
+			long seed = random.nextLong();
+			assertThat(JqwikStringSupport.displayString(gen.next(SourceOfRandomness.newRandom(seed)).value()))
+				.isEqualTo(JqwikStringSupport.displayString(gen.next(SourceOfRandomness.newRandom(seed)).value()));
+		}
+	}
 }

--- a/engine/src/test/java/net/jqwik/api/edgeCases/GenericEdgeCasesProperties.java
+++ b/engine/src/test/java/net/jqwik/api/edgeCases/GenericEdgeCasesProperties.java
@@ -30,10 +30,12 @@ public interface GenericEdgeCasesProperties {
 		@ForAll("arbitraries") Arbitrary<?> arbitrary,
 		@ForAll("arbitraryTransformations") Function<Arbitrary<?>, Arbitrary<?>> transformation,
 		@ForAll Random random,
-		@ForAll @IntRange(min = 1, max = 20) int size
+		@ForAll @IntRange(min = 1, max = 20) int size,
+		@ForAll @IntRange(min = 1, max = 1000) int genSize,
+		@ForAll boolean withEdgeCases
 	) {
 		Arbitrary<?> values = transformation.apply(arbitrary);
-		RandomGenerator<?> gen = values.generator(1000, true);
+		RandomGenerator<?> gen = values.generator(genSize, withEdgeCases);
 		for (int i = 0; i < size; i++) {
 			long seed = random.nextLong();
 			// Both values should be equal with respect to "displayString"

--- a/engine/src/test/java/net/jqwik/api/edgeCases/NumbersEdgeCasesTests.java
+++ b/engine/src/test/java/net/jqwik/api/edgeCases/NumbersEdgeCasesTests.java
@@ -18,7 +18,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class NumbersEdgeCasesTests {
 
 	private <T> Set<T> values(EdgeCases<T> edgeCases) {
-		Set<T> values = new HashSet<>();
+		Set<T> values = new LinkedHashSet<>();
 		for (Shrinkable<T> edgeCase : edgeCases) {
 			values.add(edgeCase.value());
 		}

--- a/engine/src/test/java/net/jqwik/engine/execution/JqwikExecutorTests.java
+++ b/engine/src/test/java/net/jqwik/engine/execution/JqwikExecutorTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.engine.matchers.TestDescriptorMatchers.*;
 @SuppressLogging
 public class JqwikExecutorTests {
 
-	private Set<UniqueId> previouslyFailedTests = new HashSet<>();
+	private Set<UniqueId> previouslyFailedTests = new LinkedHashSet<>();
 	private JqwikExecutor executor = new JqwikExecutor(new LifecycleHooksRegistry(), testRun -> {}, previouslyFailedTests, true, false);
 
 	@Example

--- a/engine/src/test/java/net/jqwik/engine/execution/reporting/SampleReportingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/execution/reporting/SampleReportingTests.java
@@ -339,7 +339,7 @@ class SampleReportingTests {
 		class Maps {
 			@Example
 			void fitsInOneLine() {
-				Map<String, Integer> map = new HashMap<>();
+				Map<String, Integer> map = new LinkedHashMap<>();
 				map.put("key1", 1);
 				map.put("key2", 2);
 				map.put("key3", 3);
@@ -373,7 +373,7 @@ class SampleReportingTests {
 					}
 				};
 
-				Map<String, Integer> map = new HashMap<>();
+				Map<String, Integer> map = new LinkedHashMap<>();
 				map.put("key1", 1);
 				ValueReport report = ValueReport.of(map, asList(collectionFormat));
 
@@ -391,7 +391,7 @@ class SampleReportingTests {
 
 			@Example
 			void mapOfLists() {
-				Map<String, List<String>> map = new HashMap<>();
+				Map<String, List<String>> map = new LinkedHashMap<>();
 				map.put(
 						"list1",
 						asList(

--- a/engine/src/test/java/net/jqwik/engine/matchers/IsPropertyDescriptorFor.java
+++ b/engine/src/test/java/net/jqwik/engine/matchers/IsPropertyDescriptorFor.java
@@ -20,4 +20,8 @@ class IsPropertyDescriptorFor implements ArgumentMatcher<PropertyMethodDescripto
 				&& descriptor.getTargetMethod().getName().equals(methodName);
 	}
 
+	@Override
+	public String toString() {
+		return "IsPropertyDescriptorFor(" + containerClass + ", " + methodName + ")";
+	}
 }

--- a/engine/src/test/java/net/jqwik/engine/properties/ExhaustiveShrinkablesGeneratorTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/ExhaustiveShrinkablesGeneratorTests.java
@@ -59,7 +59,7 @@ class ExhaustiveShrinkablesGeneratorTests {
 			asList(Shrinkable.unshrinkable(asList(0, 1))),
 			asList(Shrinkable.unshrinkable(asList(1, 0))),
 			asList(Shrinkable.unshrinkable(asList(1, 1))),
-			asList(Shrinkable.unshrinkable(new HashSet<>(asList(0, 1))))
+			asList(Shrinkable.unshrinkable(new LinkedHashSet<>(asList(0, 1))))
 		);
 	}
 

--- a/engine/src/test/java/net/jqwik/engine/properties/PropertyMethodArbitraryResolverTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/PropertyMethodArbitraryResolverTests.java
@@ -14,6 +14,7 @@ import net.jqwik.engine.properties.arbitraries.*;
 import net.jqwik.engine.support.*;
 import net.jqwik.testing.*;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.*;
 
 @Group
@@ -158,7 +159,7 @@ class PropertyMethodArbitraryResolverTests {
 
 				@Override
 				public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
-					return new HashSet<>(Arrays.asList(arbitraries));
+					return new LinkedHashSet<>(asList(arbitraries));
 				}
 			};
 		}

--- a/engine/src/test/java/net/jqwik/engine/properties/RandomizedShrinkablesGeneratorTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/RandomizedShrinkablesGeneratorTests.java
@@ -44,7 +44,7 @@ class RandomizedShrinkablesGeneratorTests {
 		ArbitraryResolver arbitraryResolver = new ArbitraryResolver() {
 			@Override
 			public Set<Arbitrary<?>> forParameter(MethodParameter parameter) {
-				Set<Arbitrary<?>> arbitraries = new HashSet<>();
+				Set<Arbitrary<?>> arbitraries = new LinkedHashSet<>();
 				if (parameter.getType().equals(String.class)) {
 					arbitraries.add(Arbitraries.just("a"));
 					arbitraries.add(Arbitraries.just("b"));
@@ -74,7 +74,7 @@ class RandomizedShrinkablesGeneratorTests {
 		ArbitraryResolver arbitraryResolver = new ArbitraryResolver() {
 			@Override
 			public Set<Arbitrary<?>> forParameter(MethodParameter parameter) {
-				Set<Arbitrary<?>> arbitraries = new HashSet<>();
+				Set<Arbitrary<?>> arbitraries = new LinkedHashSet<>();
 				arbitraries.add(Arbitraries.just("a"));
 				arbitraries.add(Arbitraries.just("b"));
 				return arbitraries;
@@ -95,7 +95,7 @@ class RandomizedShrinkablesGeneratorTests {
 		ArbitraryResolver arbitraryResolver = new ArbitraryResolver() {
 			@Override
 			public Set<Arbitrary<?>> forParameter(MethodParameter parameter) {
-				Set<Arbitrary<?>> arbitraries = new HashSet<>();
+				Set<Arbitrary<?>> arbitraries = new LinkedHashSet<>();
 				Arbitrary<String> a = Arbitraries.just("a");
 				Arbitrary<String> b = Arbitraries.just("b");
 				if (parameter.getType() instanceof TypeVariable) {

--- a/engine/src/test/java/net/jqwik/engine/properties/RegisteredArbitraryResolverTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/RegisteredArbitraryResolverTests.java
@@ -112,7 +112,7 @@ class RegisteredArbitraryResolverTests {
 
 			@Override
 			public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
-				return new HashSet<>(asList(arbitraries));
+				return new LinkedHashSet<>(asList(arbitraries));
 			}
 
 			@Override

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/TraverseArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/TraverseArbitraryTests.java
@@ -3,15 +3,13 @@ package net.jqwik.engine.properties.arbitraries;
 import java.lang.annotation.*;
 import java.lang.reflect.*;
 import java.util.*;
-import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.arbitraries.*;
 import net.jqwik.api.constraints.*;
 import net.jqwik.api.providers.*;
+import net.jqwik.engine.support.*;
 import net.jqwik.testing.*;
-
-import static net.jqwik.engine.support.JqwikCollectors.*;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -59,7 +57,7 @@ class TraverseArbitraryTests {
 		}
 		@Override
 		public Set<Executable> findCreators(TypeUsage targetType) {
-			return Arrays.stream(targetType.getRawType().getDeclaredConstructors()).collect(toLinkedHashSet());
+			return Arrays.stream(targetType.getRawType().getDeclaredConstructors()).collect(JqwikCollectors.toLinkedHashSet());
 		}
 	}
 

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/TraverseArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/TraverseArbitraryTests.java
@@ -11,6 +11,8 @@ import net.jqwik.api.constraints.*;
 import net.jqwik.api.providers.*;
 import net.jqwik.testing.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.*;
+
 import static org.assertj.core.api.Assertions.*;
 
 class TraverseArbitraryTests {
@@ -57,7 +59,7 @@ class TraverseArbitraryTests {
 		}
 		@Override
 		public Set<Executable> findCreators(TypeUsage targetType) {
-			return Arrays.stream(targetType.getRawType().getDeclaredConstructors()).collect(Collectors.toSet());
+			return Arrays.stream(targetType.getRawType().getDeclaredConstructors()).collect(toLinkedHashSet());
 		}
 	}
 

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableListTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableListTests.java
@@ -166,7 +166,7 @@ class ShrinkableListTests {
 		void shrinkSizeAgainAfterShrinkingElements() {
 			Shrinkable<List<Integer>> shrinkable = createShrinkableList(1, 0, 2, 1);
 
-			TestingFalsifier<List<Integer>> falsifier = integers -> integers.size() == new HashSet<>(integers).size();
+			TestingFalsifier<List<Integer>> falsifier = integers -> integers.size() == new LinkedHashSet<>(integers).size();
 			List<Integer> shrunkValue = shrink(shrinkable, falsifier, null);
 			assertThat(shrunkValue).containsExactly(0, 0);
 		}
@@ -259,7 +259,7 @@ class ShrinkableListTests {
 			List<Integer> values = Arrays.asList(56, 4, 23, 2, 95);
 			Shrinkable<List<Integer>> shrinkable = createShrinkableList(values, 2, 5, i -> i);
 
-			Predicate<List<Integer>> condition = list -> new HashSet<>(list).size() == list.size();
+			Predicate<List<Integer>> condition = list -> new LinkedHashSet<>(list).size() == list.size();
 			assertWhileShrinking(shrinkable, condition);
 		}
 
@@ -420,7 +420,7 @@ class ShrinkableListTests {
 							   .list().ofMaxSize(5)
 							   .filter(lol -> {
 								   List<Integer> allElements = lol.stream().flatMap(Collection::stream).collect(Collectors.toList());
-								   return (allElements.size() == new HashSet<>(allElements).size());
+								   return (allElements.size() == new LinkedHashSet<>(allElements).size());
 							   });
 
 			TestingFalsifier<List<Set<Integer>>> falsifier =

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableProperties.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableProperties.java
@@ -71,7 +71,7 @@ class ShrinkableProperties {
 						 .mapToObj(ignore -> Arbitraries.lazy(this::anyShrinkable))
 						 .collect(Collectors.toList());
 			return Combinators.combine(elementArbitraries).as(elements -> {
-				Set<Shrinkable> elementSet = new HashSet<>(elements);
+				Set<Shrinkable> elementSet = new LinkedHashSet<>(elements);
 				return new ShrinkableSet(elementSet, 0, size, Collections.emptySet());
 			});
 		});

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
@@ -133,7 +133,7 @@ class ShrinkableSetTests {
 				};
 
 			Set<Integer> shrunkValue = shrink(shrinkable, falsifier, null);
-			assertThat(shrunkValue).containsExactly(0, 1, 2, 3);
+			assertThat(shrunkValue).containsExactly(1, 3, 0, 2);
 		}
 
 		@Example

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
@@ -173,7 +173,7 @@ class ShrinkableSetTests {
 			}
 			return i % modulo;
 		}).collect(Collectors.toList());
-		return new HashSet<>(moduloList).size() == list.size();
+		return new LinkedHashSet<>(moduloList).size() == list.size();
 	}
 
 	@SafeVarargs

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
@@ -12,6 +12,7 @@ import net.jqwik.engine.properties.shrinking.ShrinkableTypesForTest.*;
 import net.jqwik.testing.*;
 
 import static java.util.Arrays.*;
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -138,7 +139,7 @@ class ShrinkableSetTests {
 		@Example
 		void bigSet() {
 			Set<Shrinkable<Integer>> elementShrinkables = IntStream.range(0, 1000).mapToObj(OneStepShrinkable::new)
-																   .collect(Collectors.toSet());
+																   .collect(toLinkedHashSet());
 			Shrinkable<Set<Integer>> shrinkable = new ShrinkableSet<>(elementShrinkables, 5, 1000, Collections.emptySet());
 
 			Set<Integer> shrunkValue = shrink(shrinkable, falsifier(Set::isEmpty), null);

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableSetTests.java
@@ -9,10 +9,10 @@ import net.jqwik.api.*;
 import net.jqwik.api.lifecycle.*;
 import net.jqwik.engine.properties.*;
 import net.jqwik.engine.properties.shrinking.ShrinkableTypesForTest.*;
+import net.jqwik.engine.support.*;
 import net.jqwik.testing.*;
 
 import static java.util.Arrays.*;
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -139,7 +139,7 @@ class ShrinkableSetTests {
 		@Example
 		void bigSet() {
 			Set<Shrinkable<Integer>> elementShrinkables = IntStream.range(0, 1000).mapToObj(OneStepShrinkable::new)
-																   .collect(toLinkedHashSet());
+																   .collect(JqwikCollectors.toLinkedHashSet());
 			Shrinkable<Set<Integer>> shrinkable = new ShrinkableSet<>(elementShrinkables, 5, 1000, Collections.emptySet());
 
 			Set<Integer> shrunkValue = shrink(shrinkable, falsifier(Set::isEmpty), null);

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableStringTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableStringTests.java
@@ -6,9 +6,9 @@ import java.util.stream.*;
 import net.jqwik.api.*;
 import net.jqwik.api.constraints.*;
 import net.jqwik.engine.properties.shrinking.ShrinkableTypesForTest.*;
+import net.jqwik.engine.support.*;
 import net.jqwik.testing.*;
 
-import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -93,7 +93,7 @@ public class ShrinkableStringTests {
 
 			TestingFalsifier<String> falsifier =
 					string -> {
-						Set<Integer> usedLetters = string.chars().boxed().collect(toLinkedHashSet());
+						Set<Integer> usedLetters = string.chars().boxed().collect(JqwikCollectors.toLinkedHashSet());
 						return usedLetters.size() != 1;
 					};
 

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableStringTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableStringTests.java
@@ -8,6 +8,7 @@ import net.jqwik.api.constraints.*;
 import net.jqwik.engine.properties.shrinking.ShrinkableTypesForTest.*;
 import net.jqwik.testing.*;
 
+import static net.jqwik.engine.support.JqwikCollectors.toLinkedHashSet;
 import static org.assertj.core.api.Assertions.*;
 
 import static net.jqwik.testing.ShrinkingSupport.*;
@@ -92,7 +93,7 @@ public class ShrinkableStringTests {
 
 			TestingFalsifier<String> falsifier =
 					string -> {
-						Set<Integer> usedLetters = string.chars().boxed().collect(Collectors.toSet());
+						Set<Integer> usedLetters = string.chars().boxed().collect(toLinkedHashSet());
 						return usedLetters.size() != 1;
 					};
 

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkingQualityProperties.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkingQualityProperties.java
@@ -56,7 +56,7 @@ class ShrinkingQualityProperties {
 					   .list().ofMaxSize(50);
 
 		TestingFalsifier<List<List<Integer>>> containsLessThan5DistinctNumbers = (List<List<Integer>> ls) -> {
-			Set<Integer> allElements = new HashSet<>();
+			Set<Integer> allElements = new LinkedHashSet<>();
 			for (List<Integer> x : ls) {
 				allElements.addAll(x);
 			}

--- a/engine/src/test/java/net/jqwik/engine/properties/state/ActionChainArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/state/ActionChainArbitraryTests.java
@@ -287,7 +287,7 @@ class ActionChainArbitraryTests {
 				}
 			};
 			return ActionChain.actionChains(
-				HashSet::new,
+				LinkedHashSet::new,
 				Action.just("clear", set -> {
 					set.clear();
 					return set;

--- a/engine/src/test/java/net/jqwik/engine/properties/state/ChainArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/state/ChainArbitraryTests.java
@@ -551,7 +551,7 @@ class ChainArbitraryTests {
 			TestingFalsifier<Chain<List<Integer>>> falsifier = chain -> {
 				for (List<Integer> list : chain) {
 					// Fail on duplicates
-					if (new HashSet<>(list).size() < list.size()) {
+					if (new LinkedHashSet<>(list).size() < list.size()) {
 						return false;
 					}
 				}

--- a/engine/src/test/java/net/jqwik/engine/support/CombinatoricsTests.java
+++ b/engine/src/test/java/net/jqwik/engine/support/CombinatoricsTests.java
@@ -138,7 +138,7 @@ class CombinatoricsTests {
 		}
 
 		private Set<Integer> asSet(Integer... integers) {
-			return new HashSet<>(asList(integers));
+			return new LinkedHashSet<>(asList(integers));
 		}
 
 		@Example

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/internal/PairArbitraryProvider.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/internal/PairArbitraryProvider.kt
@@ -24,6 +24,6 @@ class PairArbitraryProvider : ArbitraryProvider {
                 val second = arbitraries[1]
                 return@map anyPair(first, second)
             }
-            .collect(Collectors.toSet())
+            .collect(Collectors.toCollection(::LinkedHashSet))
     }
 }

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/internal/TripleArbitraryProvider.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/internal/TripleArbitraryProvider.kt
@@ -27,6 +27,6 @@ class TripleArbitraryProvider : ArbitraryProvider {
                 val third = arbitraries[2]
                 return@map anyTriple(first, second, third)
             }
-            .collect(Collectors.toSet())
+            .collect(Collectors.toCollection(::LinkedHashSet))
     }
 }

--- a/testing/src/main/java/net/jqwik/testing/ReportMemoryHook.java
+++ b/testing/src/main/java/net/jqwik/testing/ReportMemoryHook.java
@@ -18,7 +18,7 @@ public class ReportMemoryHook implements AroundPropertyHook {
 		double usedMemoryBefore = usedMemInMB();
 		PropertyExecutionResult result = property.execute();
 		double usedMemoryAfter = usedMemInMB();
-		Map<String, Object> memoryReport = new HashMap<>();
+		Map<String, Object> memoryReport = new LinkedHashMap<>();
 		memoryReport.put("used memory before", String.format("%s MB", usedMemoryBefore));
 		memoryReport.put("used memory after", String.format("%s MB", usedMemoryAfter));
 		context.reporter().publishReport(context.extendedLabel(), memoryReport);

--- a/testing/src/main/java/net/jqwik/testing/TestingSupport.java
+++ b/testing/src/main/java/net/jqwik/testing/TestingSupport.java
@@ -120,7 +120,7 @@ public class TestingSupport {
 	}
 
 	public static <T> Set<Shrinkable<T>> collectEdgeCaseShrinkables(EdgeCases<T> edgeCases) {
-		Set<Shrinkable<T>> shrinkables = new HashSet<>();
+		Set<Shrinkable<T>> shrinkables = new LinkedHashSet<>();
 		for (Shrinkable<T> edgeCase : edgeCases) {
 			shrinkables.add(edgeCase);
 		}
@@ -128,7 +128,7 @@ public class TestingSupport {
 	}
 
 	public static <T> Set<T> collectEdgeCaseValues(EdgeCases<T> edgeCases) {
-		Set<T> values = new HashSet<>();
+		Set<T> values = new LinkedHashSet<>();
 		for (Shrinkable<T> edgeCase : edgeCases) {
 			values.add(edgeCase.value());
 		}

--- a/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/AllowedDayOfWeeks.java
+++ b/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/AllowedDayOfWeeks.java
@@ -7,7 +7,7 @@ public class AllowedDayOfWeeks extends AllowedUnits<DayOfWeek> {
 
 	@Override
 	protected void setDefaultAllowed() {
-		allowed = new HashSet<>(Arrays.asList(DayOfWeek.values()));
+		allowed = new LinkedHashSet<>(Arrays.asList(DayOfWeek.values()));
 	}
 
 }

--- a/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/AllowedMonths.java
+++ b/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/AllowedMonths.java
@@ -8,13 +8,13 @@ public class AllowedMonths extends AllowedUnits<Month> {
 
 	@Override
 	protected void setDefaultAllowed() {
-		allowed = new HashSet<>(Arrays.asList(Month.values()));
+		allowed = new LinkedHashSet<>(Arrays.asList(Month.values()));
 	}
 
 	public void set(MonthBetween monthBetween) {
 		allowed = Arrays.stream(Month.values())
 						.filter(m -> m.compareTo(monthBetween.getMin()) >= 0 && m.compareTo(monthBetween.getMax()) <= 0)
-						.collect(Collectors.toSet());
+						.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 }

--- a/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/AllowedUnits.java
+++ b/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/AllowedUnits.java
@@ -15,7 +15,7 @@ public abstract class AllowedUnits<T> {
 
 	@SafeVarargs
 	public final void set(T... values) {
-		allowed = new HashSet<>(Arrays.asList(values));
+		allowed = new LinkedHashSet<>(Arrays.asList(values));
 	}
 
 	public Set<T> get() {

--- a/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/OfPrecision.java
+++ b/time/src/main/java/net/jqwik/time/internal/properties/arbitraries/valueRanges/OfPrecision.java
@@ -11,7 +11,7 @@ public class OfPrecision {
 
 	public final static ChronoUnit DEFAULT = SECONDS;
 
-	private final static Set<ChronoUnit> ALLOWED_PRECISIONS = new HashSet<>(Arrays.asList(HOURS, MINUTES, SECONDS, MILLIS, MICROS, NANOS));
+	private final static Set<ChronoUnit> ALLOWED_PRECISIONS = new LinkedHashSet<>(Arrays.asList(HOURS, MINUTES, SECONDS, MILLIS, MICROS, NANOS));
 
 	private ChronoUnit precision = DEFAULT;
 	private boolean precisionSet = false;

--- a/time/src/test/java/net/jqwik/time/api/dates/monthDay/EdgeCasesTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/monthDay/EdgeCasesTests.java
@@ -18,10 +18,13 @@ public class EdgeCasesTests {
 		MonthDayArbitrary monthDays = Dates.monthDays();
 		Set<MonthDay> edgeCases = collectEdgeCaseValues(monthDays.edgeCases());
 		assertThat(edgeCases).hasSize(3);
+		// February 29 is added via edgeCases.add in net.jqwik.time.internal.properties.arbitraries.DefaultLocalDateArbitrary.arbitrary
+		// And net.jqwik.engine.properties.arbitraries.GenericEdgeCasesConfiguration.configure adds all the explicitly
+		// added edge cases to the end of the list. So February 29 is generated the last.
 		assertThat(edgeCases).containsExactly(
 			MonthDay.of(Month.JANUARY, 1),
-			MonthDay.of(Month.FEBRUARY, 29),
-			MonthDay.of(Month.DECEMBER, 31)
+			MonthDay.of(Month.DECEMBER, 31),
+			MonthDay.of(Month.FEBRUARY, 29)
 		);
 	}
 

--- a/web/src/test/java/net/jqwik/web/api/EmailsTests.java
+++ b/web/src/test/java/net/jqwik/web/api/EmailsTests.java
@@ -253,7 +253,7 @@ public class EmailsTests {
 			Set<String> localParts = collectEdgeCaseValues(emails.edgeCases())
 											 .stream()
 											 .map(WebTestingSupport::getLocalPartOfEmail)
-											 .collect(Collectors.toSet());
+											 .collect(Collectors.toCollection(LinkedHashSet::new));
 
 			assertThat(localParts).containsExactlyInAnyOrder("a", "A", "0");
 		}
@@ -264,7 +264,7 @@ public class EmailsTests {
 			Set<String> localParts = collectEdgeCaseValues(emails.edgeCases())
 											 .stream()
 											 .map(WebTestingSupport::getLocalPartOfEmail)
-											 .collect(Collectors.toSet());
+											 .collect(Collectors.toCollection(LinkedHashSet::new));
 
 			assertThat(localParts).containsExactlyInAnyOrder("\"a\"", "\" \"");
 		}
@@ -275,7 +275,7 @@ public class EmailsTests {
 			Set<String> hosts = collectEdgeCaseValues(emails.edgeCases())
 											 .stream()
 											 .map(WebTestingSupport::getEmailHost)
-											 .collect(Collectors.toSet());
+											 .collect(Collectors.toCollection(LinkedHashSet::new));
 
 			assertThat(hosts).containsExactlyInAnyOrder("a.aa", "0.aa");
 		}
@@ -286,7 +286,7 @@ public class EmailsTests {
 			Set<String> hosts = collectEdgeCaseValues(emails.edgeCases())
 											 .stream()
 											 .map(WebTestingSupport::getEmailHost)
-											 .collect(Collectors.toSet());
+											 .collect(Collectors.toCollection(LinkedHashSet::new));
 
 			assertThat(hosts).contains(
 					"[0.0.0.0]", "[255.255.255.255]", "[127.0.0.1]"
@@ -299,7 +299,7 @@ public class EmailsTests {
 			Set<String> hosts = collectEdgeCaseValues(emails.edgeCases())
 											 .stream()
 											 .map(WebTestingSupport::getEmailHost)
-											 .collect(Collectors.toSet());
+											 .collect(Collectors.toCollection(LinkedHashSet::new));
 
 			assertThat(hosts).contains(
 					"[::]",


### PR DESCRIPTION
See https://github.com/policeman-tools/forbidden-apis/wiki/GradleUsage
See https://github.com/policeman-tools/forbidden-apis/wiki/SignaturesSyntax

## Overview

forbidden-apis allows identify the usage of unwanted APIs.
For instance, `Collections#toSet` can yield non-reproducible outcomes, and I believe it is important that Jqwik could reproduce the same generation and shrinking sequences based on the input seed only.

See one of the issues in https://github.com/jlink/jqwik/issues/340


### Details

There are out-of-the-box signatures that might be helpful: https://github.com/policeman-tools/forbidden-apis/wiki/BundledSignatures

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
