### PR TITLE
Add com.github.vlsi.gradle-extensions to make test output human-readable

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,3 +11,7 @@ repositories {
     // Use the plugin portal to apply community plugins in convention plugins.
     gradlePluginPortal()
 }
+
+dependencies {
+	implementation 'com.github.vlsi.gradle-extensions:com.github.vlsi.gradle-extensions.gradle.plugin:1.78'
+}

--- a/buildSrc/src/main/groovy/jqwik.common-configuration.gradle
+++ b/buildSrc/src/main/groovy/jqwik.common-configuration.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java-library'
 	id 'maven-publish'
 	id 'signing'
+	// See https://github.com/vlsi/vlsi-release-plugins/blob/master/plugins/gradle-extensions-plugin/README.md
+	id 'com.github.vlsi.gradle-extensions'
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+# com.github.vlsi.gradle-extensions prints only failing or slow test results
+slowTestLogThreshold=15000
+slowSuiteLogThreshold=30000


### PR DESCRIPTION
## Overview

I might be biased, however, I believe https://github.com/vlsi/vlsi-release-plugins/blob/master/plugins/gradle-extensions-plugin/README.md#test-output-formatting makes CI output much easier to understand.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
