### PR TITLE
ci: use burrunan/gradle-cache-action for launching Gradle

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,10 +32,13 @@ jobs:
           java-version: ${{ matrix.Java }}
           check-latest: true
 
-      - name: Build and Test
-        run: |
-          ./gradlew --version
-          ./gradlew test --info
+      - uses: burrunan/gradle-cache-action@v1
+        # See https://github.com/burrunan/gradle-cache-action
+        name: Build and Test
+        with:
+          # It allows different cache contents for different JDKs
+          job-id: java${{ matrix.java }}
+          arguments: check
 
       - name: Publish Test Report
         uses: scacap/action-surefire-report@v1


### PR DESCRIPTION
The current CI logs contain a lot of noise regarding Gradle initialization and dependency retrieval.

`burrunan/gradle-cache-action` simplifies cross-platform Gradle execution, and it caches dependencies. 

See https://github.com/burrunan/gradle-cache-action

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
