### PR TITLE
ci: use GitHub workflow concurrency feature to cancel stale PR jobs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - '*'
 
+concurrency:
+  # On main, we don't want any jobs cancelled so the sha is used to name the group
+  # On PR branches, we cancel the job if new commits are pushed
+  # More info: https://stackoverflow.com/a/68422069/253468
+  group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-main-{0}', github.ref) }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
It will automatically cancel the past CI jobs in case PR is updated with a new commit


---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
