### PR TITLE
Remove FeatureExtractor#applySafe to let the error propagate

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/properties/FeatureExtractor.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/FeatureExtractor.java
@@ -10,26 +10,18 @@ public interface FeatureExtractor<T> extends Function<T, Object> {
 		return t -> t;
 	}
 
-	default Object applySafe(T t) {
-		try {
-			return apply(t);
-		} catch (NullPointerException npe) {
-			return null;
-		}
-	}
-
 	default boolean isUniqueIn(T value, Collection<T> elements) {
 		if (this == identity()) {
 			return !elements.contains(value);
 		}
-		Object feature = applySafe(value);
+		Object feature = apply(value);
 		return elements.stream()
-					   .map(this::applySafe)
+					   .map(this)
 					   .noneMatch(x -> Objects.equals(x, feature));
 	}
 
 	default boolean areUnique(Collection<T> elements) {
-		long uniqueCount = elements.stream().map(this::applySafe).distinct().count();
+		long uniqueCount = elements.stream().map(this).distinct().count();
 		return uniqueCount == elements.size();
 	}
 }

--- a/engine/src/test/java/net/jqwik/api/ListArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/ListArbitraryTests.java
@@ -97,7 +97,7 @@ class ListArbitraryTests {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 1000).injectNull(0.5)
 					   .list().ofMaxSize(20)
-					   .uniqueElements(i -> i % 100);
+					   .uniqueElements(i -> i == null ? null : i % 100);
 
 		RandomGenerator<List<Integer>> generator = listArbitrary.generator(1000, true);
 


### PR DESCRIPTION
## Overview

This PR removes `FeatureExtractor#applySafe`.

### Details

The current implementation might hide exceptions in the user-provided code, so it might make error understanding harder than it could be.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
