### PR TITLE
Fix link to builders section anchor

### DIFF
--- a/documentation/src/docs/include/customized-parameter-generation.md
+++ b/documentation/src/docs/include/customized-parameter-generation.md
@@ -1073,7 +1073,7 @@ If you need more you have a few options:
 - Consider to group some parameters into an object of their own and change your design
 - Generate inbetween arbitraries e.g. of type `Tuple` and combine those in another step
 - Introduce a build for your domain object and combine them
-  [in this way](#combining-arbitraries-with-builder)
+  [in this way](#combining-arbitraries-with-builders)
 
 #### Flat Combination
 


### PR DESCRIPTION
## Overview

The current link doesn't work because the anchor is named differently

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
