### PR TITLE
docs: Fix minor typos

### DIFF
--- a/documentation/src/docs/include/contract-tests.md
+++ b/documentation/src/docs/include/contract-tests.md
@@ -3,7 +3,7 @@ you can do some kind of _contract testing_. That means that you specify
 the properties in a generically typed interface and specify the concrete class to
 instantiate in a test container implementing the interface.
 
-The following example was influence by a similar feature in
+The following example was influenced by a similar feature in
 [junit-quickcheck](http://pholser.github.io/junit-quickcheck/site/0.8/usage/contract-tests.html).
 Here's the contract:
 

--- a/documentation/src/docs/include/using-arbitraries-directly.md
+++ b/documentation/src/docs/include/using-arbitraries-directly.md
@@ -69,9 +69,9 @@ _jqwik_ will do all the combinations and filtering for you.
 
 ### Using Arbitraries Outside Jqwik Lifecycle
 
-All the methode mentioned in this chapter can be used outside a property, 
+All the methods mentioned in this chapter can be used outside a property, 
 which also means outside jqwik's lifecycle control. 
-Probably the most prominent reason to that is to experiment with arbitraries
+Probably the most prominent reason to do that is to experiment with arbitraries
 and value generation in a Java console or a main method.
 Another reason can be to use jqwik's data generation capabilities for testing
 data in Jupiter or Cucumber tests.


### PR DESCRIPTION
## Overview

"methode" should be "methods", a sentence was missing a verb, and "was influence" should be "was influenced"

### Details

N/A

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
