### PR TITLE
WIP: use L128X1024Mix for random generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,4 +37,4 @@ Use _jqwik_ itself for all tests and properties.
 
 Use _AssertJ_ for non trivial assertions.
 
-Use `@ForAll Random random` parameter if you need a random value. 
+Use `@ForAll JqwikRandom random` parameter if you need a random value. 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -53,4 +53,6 @@ signing {
 dependencies {
 	api("org.opentest4j:opentest4j:${opentest4jVersion}")
 	api("org.junit.platform:junit-platform-commons:${junitPlatformVersion}")
+	api(platform("org.apache.commons:commons-rng-bom:1.5"))
+	api("org.apache.commons:commons-rng-client-api")
 }

--- a/api/src/main/java/net/jqwik/api/Arbitraries.java
+++ b/api/src/main/java/net/jqwik/api/Arbitraries.java
@@ -111,7 +111,7 @@ public class Arbitraries {
 	 * @param <T>       The type of values to generate
 	 * @return a new arbitrary instance
 	 */
-	public static <T> Arbitrary<T> randomValue(Function<Random, T> generator) {
+	public static <T> Arbitrary<T> randomValue(Function<JqwikRandom, T> generator) {
 		return fromGenerator(random -> Shrinkable.unshrinkable(generator.apply(random)));
 	}
 
@@ -120,8 +120,8 @@ public class Arbitraries {
 	 *
 	 * @return a new arbitrary instance
 	 */
-	public static Arbitrary<Random> randoms() {
-		return randomValue(random -> new Random(random.nextLong()));
+	public static Arbitrary<JqwikRandom> randoms() {
+		return randomValue(JqwikRandom::split);
 	}
 
 	/**

--- a/api/src/main/java/net/jqwik/api/JqwikRandom.java
+++ b/api/src/main/java/net/jqwik/api/JqwikRandom.java
@@ -1,0 +1,37 @@
+package net.jqwik.api;
+
+import net.jqwik.api.random.*;
+
+import org.apache.commons.rng.*;
+
+import java.util.*;
+
+public interface JqwikRandom extends UniformRandomProvider {
+	JqwikRandom jump();
+	
+	default JqwikRandom split() {
+		return split(this);
+	}
+	
+	JqwikRandom split(UniformRandomProvider source);
+	
+	JqwikRandomState saveState();
+	
+	void restoreState(JqwikRandomState state);
+	
+	default Random asJdkRandom() {
+		return new Random() {
+			@Override
+			protected int next(int bits) {
+				int next = JqwikRandom.this.nextInt();
+				next &= ((1L << bits) - 1);
+				return next;
+			}
+
+			@Override
+			public long nextLong() {
+				return JqwikRandom.this.nextLong();
+			}
+		};
+	}
+}

--- a/api/src/main/java/net/jqwik/api/RandomDistribution.java
+++ b/api/src/main/java/net/jqwik/api/RandomDistribution.java
@@ -1,7 +1,6 @@
 package net.jqwik.api;
 
 import java.math.*;
-import java.util.*;
 
 import org.apiguardian.api.*;
 
@@ -61,7 +60,7 @@ public interface RandomDistribution {
 		 *
 		 * @return an instance of BigInteger. Never {@code null}.
 		 */
-		BigInteger next(Random random);
+		BigInteger next(JqwikRandom random);
 	}
 
 	/**

--- a/api/src/main/java/net/jqwik/api/Shrinkable.java
+++ b/api/src/main/java/net/jqwik/api/Shrinkable.java
@@ -5,6 +5,8 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
 
+import net.jqwik.api.random.*;
+
 import org.apiguardian.api.*;
 
 import static org.apiguardian.api.API.Status.*;
@@ -26,7 +28,7 @@ public interface Shrinkable<T> extends Comparable<Shrinkable<T>> {
 
 		public abstract <T> Shrinkable<T> filter(Shrinkable<T> self, Predicate<T> filter);
 
-		public abstract <T, U> Shrinkable<U> flatMap(Shrinkable<T> self, Function<T, Arbitrary<U>> flatMapper, int tries, long randomSeed);
+		public abstract <T, U> Shrinkable<U> flatMap(Shrinkable<T> self, Function<T, Arbitrary<U>> flatMapper, int tries, JqwikRandomState randomSeed);
 	}
 
 	static <T> Shrinkable<T> unshrinkable(@Nullable T value) {
@@ -106,7 +108,7 @@ public interface Shrinkable<T> extends Comparable<Shrinkable<T>> {
 		return ShrinkableFacade.implementation.filter(this, filter);
 	}
 
-	default <U> Shrinkable<U> flatMap(Function<T, Arbitrary<U>> flatMapper, int tries, long randomSeed) {
+	default <U> Shrinkable<U> flatMap(Function<T, Arbitrary<U>> flatMapper, int tries, JqwikRandomState randomSeed) {
 		return ShrinkableFacade.implementation.flatMap(this, flatMapper, tries, randomSeed);
 	}
 

--- a/api/src/main/java/net/jqwik/api/facades/ShrinkingSupportFacade.java
+++ b/api/src/main/java/net/jqwik/api/facades/ShrinkingSupportFacade.java
@@ -1,7 +1,5 @@
 package net.jqwik.api.facades;
 
-import java.util.*;
-
 import org.apiguardian.api.*;
 
 import net.jqwik.api.*;
@@ -17,9 +15,9 @@ public abstract class ShrinkingSupportFacade {
 		implementation = FacadeLoader.load(ShrinkingSupportFacade.class);
 	}
 
-	public abstract <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, Random random, Falsifier<T> falsifier);
+	public abstract <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, JqwikRandom random, Falsifier<T> falsifier);
 
-	public abstract <T> T falsifyThenShrink(RandomGenerator<? extends T> arbitrary, Random random, Falsifier<T> falsifier);
+	public abstract <T> T falsifyThenShrink(RandomGenerator<? extends T> arbitrary, JqwikRandom random, Falsifier<T> falsifier);
 
 	public abstract <T> T shrink(
 			Shrinkable<T> falsifiedShrinkable,

--- a/api/src/main/java/net/jqwik/api/facades/TestingSupportFacade.java
+++ b/api/src/main/java/net/jqwik/api/facades/TestingSupportFacade.java
@@ -13,7 +13,7 @@ public abstract class TestingSupportFacade {
 		implementation = FacadeLoader.load(TestingSupportFacade.class);
 	}
 
-	public abstract <T> Shrinkable<T> generateUntil(RandomGenerator<T> generator, Random random, Function<T, Boolean> condition);
+	public abstract <T> Shrinkable<T> generateUntil(RandomGenerator<T> generator, JqwikRandom random, Function<T, Boolean> condition);
 
 	public abstract String singleLineReport(Object any);
 

--- a/api/src/main/java/net/jqwik/api/random/JqwikRandomSeed.java
+++ b/api/src/main/java/net/jqwik/api/random/JqwikRandomSeed.java
@@ -1,0 +1,4 @@
+package net.jqwik.api.random;
+
+public interface JqwikRandomSeed {
+}

--- a/api/src/main/java/net/jqwik/api/random/JqwikRandomState.java
+++ b/api/src/main/java/net/jqwik/api/random/JqwikRandomState.java
@@ -1,0 +1,5 @@
+package net.jqwik.api.random;
+
+public interface JqwikRandomState {
+	Object getAlgorithm();
+}

--- a/documentation/src/docs/include/customized-parameter-generation.md
+++ b/documentation/src/docs/include/customized-parameter-generation.md
@@ -195,7 +195,7 @@ The starting point for generation usually is a static method call on class
       return Arbitraries.randomValue(random -> generatePrime(random));
   }
 
-  private Integer generatePrime(Random random) {
+  private Integer generatePrime(JqwikRandom random) {
       int candidate;
       do {
           candidate = random.nextInt(10000) + 2;
@@ -309,7 +309,7 @@ Arbitraries.strings().ofMinLength(5).ofMaxLength(25)
 
 #### java.util.Random
 
-- [`Arbitrary<Random> randoms()`](/docs/${docsVersion}/javadoc/net/jqwik/api/Arbitraries.html#randoms()):
+- [`Arbitrary<JqwikRandom> randoms()`](/docs/${docsVersion}/javadoc/net/jqwik/api/Arbitraries.html#randoms()):
   Random instances will never be shrunk
 
 #### Shuffling Permutations

--- a/documentation/src/docs/include/lifecycle-hooks.md
+++ b/documentation/src/docs/include/lifecycle-hooks.md
@@ -189,7 +189,7 @@ and publish the result using a [`Reporter`](/docs/${docsVersion}/javadoc/net/jqw
 ```java
 @Property(tries = 100)
 @AddLifecycleHook(MeasureTime.class)
-void measureTimeSpent(@ForAll Random random) throws InterruptedException {
+void measureTimeSpent(@ForAll JqwikRandom random) throws InterruptedException {
     Thread.sleep(random.nextInt(50));
 }
 
@@ -228,7 +228,7 @@ The following example shows how to fail if a single try will take longer than 10
 ```java
 @Property(tries = 10)
 @AddLifecycleHook(FailIfTooSlow.class)
-void sleepingProperty(@ForAll Random random) throws InterruptedException {
+void sleepingProperty(@ForAll JqwikRandom random) throws InterruptedException {
     Thread.sleep(random.nextInt(101));
 }
 

--- a/documentation/src/test/java/net/jqwik/docs/lifecycle/AroundPropertyHookExamples.java
+++ b/documentation/src/test/java/net/jqwik/docs/lifecycle/AroundPropertyHookExamples.java
@@ -38,7 +38,7 @@ class AroundPropertyHookExamples implements AutoCloseable {
 
 	@Property(tries = 100)
 	@AddLifecycleHook(MeasureTime.class)
-	void measureTimeSpent(@ForAll Random random) throws InterruptedException {
+	void measureTimeSpent(@ForAll JqwikRandom random) throws InterruptedException {
 		Thread.sleep(random.nextInt(50));
 	}
 

--- a/documentation/src/test/java/net/jqwik/docs/lifecycle/AroundTryHookExamples.java
+++ b/documentation/src/test/java/net/jqwik/docs/lifecycle/AroundTryHookExamples.java
@@ -11,7 +11,7 @@ class AroundTryHookExamples {
 
 	@Property(tries = 10)
 	@AddLifecycleHook(FailIfTooSlow.class)
-	void sleepingProperty(@ForAll Random random) throws InterruptedException {
+	void sleepingProperty(@ForAll JqwikRandom random) throws InterruptedException {
 		Thread.sleep(random.nextInt(101));
 	}
 

--- a/engine/build.gradle
+++ b/engine/build.gradle
@@ -82,6 +82,8 @@ dependencies {
 	api("org.opentest4j:opentest4j:${opentest4jVersion}")
 	api("org.junit.platform:junit-platform-commons:${junitPlatformVersion}")
 	implementation("org.junit.platform:junit-platform-engine:${junitPlatformVersion}")
+	implementation("org.apache.commons:commons-rng-core")
+	implementation("org.apache.commons:commons-rng-simple")
 
 	testImplementation(project(":testing"))
 

--- a/engine/src/main/java/net/jqwik/engine/SourceOfRandomness.java
+++ b/engine/src/main/java/net/jqwik/engine/SourceOfRandomness.java
@@ -1,27 +1,71 @@
 package net.jqwik.engine;
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.function.*;
+import java.math.*;
+import java.nio.*;
 
 import net.jqwik.api.*;
+
+import net.jqwik.api.random.*;
+
+import net.jqwik.engine.random.*;
+
+import org.apache.commons.rng.*;
+import org.apache.commons.rng.core.*;
+import org.apache.commons.rng.core.source64.*;
+import org.apache.commons.rng.simple.*;
+import org.jetbrains.annotations.*;
+import sun.reflect.generics.reflectiveObjects.*;
 
 public class SourceOfRandomness {
 
 	private SourceOfRandomness() {
 	}
 
-	private static final Supplier<Random> RNG = ThreadLocalRandom::current;
+	private static final RandomSource DEFAULT_ALGORITHM = RandomSource.L128_X1024_MIX;
 
-	private static final ThreadLocal<Random> current = ThreadLocal.withInitial(SourceOfRandomness::newRandom);
+	private static final ThreadLocal<JqwikRandom> current = ThreadLocal.withInitial(SourceOfRandomness::newRandom);
 
-	public static String createRandomSeed() {
-		return Long.toString(RNG.get().nextLong());
+	private static String encodeBase36(byte[] bytes) {
+		return new BigInteger(bytes).toString(36);
 	}
 
-	public static Random create(String seed) {
+	public static byte[] decodeBase36(String seed) {
+		return new BigInteger(seed, 36).toByteArray();
+	}
+	
+	public static String createRandomSeed() {
+		return "1_" + DEFAULT_ALGORITHM.name() + "_" + encodeBase36(DEFAULT_ALGORITHM.createSeed());
+	}
+
+	public static JqwikRandomState createSeed(RandomSource algorithm, byte[] seed) {
+		return new SeedBasedRandomState(algorithm, seed);
+	}
+
+	public static JqwikRandomState createSeed(RandomSource algorithm, long seed) {
+		return createSeed(algorithm, longBytes(seed));
+	}
+
+	private static byte[] longBytes(long seed) {
+		return ByteBuffer.allocate(Long.BYTES).putLong(seed).array();
+	}
+
+	public static JqwikRandomState createSeed(String seed) {
+		RandomSource algorithm = DEFAULT_ALGORITHM;
+		byte[] seedBytes;
+		if (seed.startsWith("1_L128_X1024_MIX_")) {
+			seedBytes = decodeBase36(seed.substring("1_L128_X1024_MIX_".length()));
+		} else if (!seed.startsWith("1_")) {
+			seedBytes = longBytes(Long.parseLong(seed));
+		} else {
+			throw new UnsupportedOperationException("TODO: implement parsing of 1_ seed");
+		}
+		return createSeed(algorithm, seedBytes);
+	}
+
+	public static JqwikRandom create(String seed) {
 		try {
-			Random random = newRandom(Long.parseLong(seed));
+			JqwikRandomState state = createSeed(seed);
+			JqwikRandom random = newRandom(state);
 			current.set(random);
 			return random;
 		} catch (NumberFormatException nfe) {
@@ -29,73 +73,23 @@ public class SourceOfRandomness {
 		}
 	}
 
-	public static Random newRandom() {
-		return new XORShiftRandom();
+	public static JqwikRandom newRandom() {
+		return newRandom(RandomSource.createLong());
 	}
 
-	public static Random newRandom(final long seed) {
-		return new XORShiftRandom(seed);
+	@Deprecated
+	public static JqwikRandom newRandom(final long seed) {
+		return newRandom(createSeed(DEFAULT_ALGORITHM, seed));
 	}
 
-	public static Random current() {
+	public static JqwikRandom newRandom(final JqwikRandomState seed) {
+		return new JqwikRandomImpl(
+			(RandomSource) seed.getAlgorithm(),
+			((BaseRandomState) seed).createGenerator()
+		);
+	}
+
+	public static JqwikRandom current() {
 		return current.get();
-	}
-
-	/**
-	 * A faster but not thread safe implementation of {@linkplain java.util.Random}.
-	 * It also has a period of 2^n - 1 and better statistical randomness.
-	 *
-	 * See for details: https://www.javamex.com/tutorials/random_numbers/xorshift.shtml
-	 *
-	 * <p>
-	 * For further performance improvements within jqwik, consider to override:
-	 * <ul>
-	 *     <li>nextDouble()</li>
-	 *     <li>nextBytes(int)</li>
-	 * </ul>
-	 */
-	private static class XORShiftRandom extends Random {
-		private long seed;
-
-		private XORShiftRandom() {
-			this(System.nanoTime());
-		}
-
-		private XORShiftRandom(long seed) {
-			this.seed = mix64(seed);
-			if (this.seed == 0) {
-				// 0 is invalid for XorShift seed, so we set it to a non-zero value
-				this.seed = 0xbf58476d1ce4e5b9L;
-			}
-		}
-
-		/**
-		* See <a href="http://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html">Better Bit Mixing - Improving on MurmurHash3's 64-bit Finalizer</a>
-		*/
-		private static long mix64(long z) {
-			z = (z ^ (z >>> 30)) * 0xbf58476d1ce4e5b9L;
-			z = (z ^ (z >>> 27)) * 0x94d049bb133111ebL;
-			return z ^ (z >>> 31);
-		}
-
-		@Override
-		protected int next(int nbits) {
-			long x = nextLong();
-			x &= ((1L << nbits) - 1);
-			return (int) x;
-		}
-
-		/**
-		 * Will never generate 0L
-		 */
-		@Override
-		public long nextLong() {
-			long x = this.seed;
-			x ^= (x << 21);
-			x ^= (x >>> 35);
-			x ^= (x << 4);
-			this.seed = x;
-			return x;
-		}
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/execution/CheckedProperty.java
+++ b/engine/src/main/java/net/jqwik/engine/execution/CheckedProperty.java
@@ -232,7 +232,7 @@ public class CheckedProperty {
 	}
 
 	private ForAllParametersGenerator createRandomizedShrinkablesGenerator(PropertyConfiguration configuration) {
-		Random random = SourceOfRandomness.create(configuration.getSeed());
+		JqwikRandom random = SourceOfRandomness.create(configuration.getSeed());
 		return RandomizedShrinkablesGenerator.forParameters(
 			forAllParameters,
 			arbitraryResolver,

--- a/engine/src/main/java/net/jqwik/engine/facades/RandomGeneratorFacadeImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/RandomGeneratorFacadeImpl.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.random.JqwikRandomState;
 import net.jqwik.engine.properties.arbitraries.randomized.*;
 import net.jqwik.engine.properties.shrinking.*;
 
@@ -12,17 +13,17 @@ import net.jqwik.engine.properties.shrinking.*;
  */
 public class RandomGeneratorFacadeImpl extends RandomGenerator.RandomGeneratorFacade {
 	@Override
-	public <T, U> Shrinkable<U> flatMap(Shrinkable<T> self, Function<T, RandomGenerator<U>> mapper, long nextLong) {
+	public <T, U> Shrinkable<U> flatMap(Shrinkable<T> self, Function<T, RandomGenerator<U>> mapper, JqwikRandomState nextLong) {
 		return new FlatMappedShrinkable<>(self, mapper, nextLong);
 	}
 
 	@Override
 	public <T, U> Shrinkable<U> flatMap(
-			Shrinkable<T> self,
-			Function<T, Arbitrary<U>> mapper,
-			int genSize,
-			long nextLong,
-			boolean withEmbeddedEdgeCases
+		Shrinkable<T> self,
+		Function<T, Arbitrary<U>> mapper,
+		int genSize,
+		JqwikRandomState nextLong,
+		boolean withEmbeddedEdgeCases
 	) {
 		return new FlatMappedShrinkable<>(self, mapper, genSize, nextLong, withEmbeddedEdgeCases);
 	}

--- a/engine/src/main/java/net/jqwik/engine/facades/ShrinkableFacadeImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/ShrinkableFacadeImpl.java
@@ -3,6 +3,7 @@ package net.jqwik.engine.facades;
 import java.util.function.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.random.*;
 import net.jqwik.engine.properties.shrinking.*;
 
 /**
@@ -25,7 +26,7 @@ public class ShrinkableFacadeImpl extends Shrinkable.ShrinkableFacade {
 	}
 
 	@Override
-	public <T, U> Shrinkable<U> flatMap(Shrinkable<T> self, Function<T, Arbitrary<U>> flatMapper, int tries, long randomSeed) {
+	public <T, U> Shrinkable<U> flatMap(Shrinkable<T> self, Function<T, Arbitrary<U>> flatMapper, int tries, JqwikRandomState randomSeed) {
 		return new FlatMappedShrinkable<>(self, flatMapper, tries, randomSeed, false);
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/facades/ShrinkingSupportFacadeImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/ShrinkingSupportFacadeImpl.java
@@ -15,7 +15,7 @@ public class ShrinkingSupportFacadeImpl extends ShrinkingSupportFacade {
 	private final TestingSupportFacadeImpl testingSupportFacade = new TestingSupportFacadeImpl();
 
 	@Override
-	public <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, Random random, Falsifier<T> falsifier) {
+	public <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, JqwikRandom random, Falsifier<T> falsifier) {
 		RandomGenerator<? extends T> generator = arbitrary.generator(10, true);
 		return falsifyThenShrink(generator, random, falsifier);
 	}
@@ -23,9 +23,9 @@ public class ShrinkingSupportFacadeImpl extends ShrinkingSupportFacade {
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T falsifyThenShrink(
-			RandomGenerator<? extends T> generator,
-			Random random,
-			Falsifier<T> falsifier
+		RandomGenerator<? extends T> generator,
+		JqwikRandom random,
+		Falsifier<T> falsifier
 	) {
 		Throwable[] originalError = new Throwable[1];
 		Shrinkable<T> falsifiedShrinkable =

--- a/engine/src/main/java/net/jqwik/engine/facades/TestingSupportFacadeImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/facades/TestingSupportFacadeImpl.java
@@ -10,7 +10,7 @@ import net.jqwik.engine.execution.reporting.*;
 public class TestingSupportFacadeImpl extends TestingSupportFacade {
 
 	@Override
-	public  <T> Shrinkable<T> generateUntil(RandomGenerator<T> generator, Random random, Function<T, Boolean> condition) {
+	public  <T> Shrinkable<T> generateUntil(RandomGenerator<T> generator, JqwikRandom random, Function<T, Boolean> condition) {
 		long maxTries = 1000;
 		return generator
 					   .stream(random)

--- a/engine/src/main/java/net/jqwik/engine/properties/PurelyRandomShrinkablesGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/PurelyRandomShrinkablesGenerator.java
@@ -14,7 +14,7 @@ class PurelyRandomShrinkablesGenerator {
 		this.parameterGenerators = parameterGenerators;
 	}
 
-	List<Shrinkable<Object>> generateNext(Random random) {
+	List<Shrinkable<Object>> generateNext(JqwikRandom random) {
 		Map<TypeUsage, Arbitrary<Object>> generatorsCache = new LinkedHashMap<>();
 		return parameterGenerators
 				   .stream()

--- a/engine/src/main/java/net/jqwik/engine/properties/RandomizedParameterGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/RandomizedParameterGenerator.java
@@ -20,12 +20,12 @@ class RandomizedParameterGenerator {
 		this.withEdgeCases = withEdgeCases;
 	}
 
-	Shrinkable<Object> next(Random random, Map<TypeUsage, Arbitrary<Object>> arbitrariesCache) {
+	Shrinkable<Object> next(JqwikRandom random, Map<TypeUsage, Arbitrary<Object>> arbitrariesCache) {
 		RandomGenerator<Object> selectedGenerator = selectGenerator(random, arbitrariesCache);
 		return selectedGenerator.next(random);
 	}
 
-	private RandomGenerator<Object> selectGenerator(Random random, Map<TypeUsage, Arbitrary<Object>> arbitrariesCache) {
+	private RandomGenerator<Object> selectGenerator(JqwikRandom random, Map<TypeUsage, Arbitrary<Object>> arbitrariesCache) {
 		if (arbitrariesCache.containsKey(typeUsage)) {
 			Arbitrary<Object> arbitrary = arbitrariesCache.get(typeUsage);
 			return getGenerator(arbitrary);

--- a/engine/src/main/java/net/jqwik/engine/properties/RandomizedShrinkablesGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/RandomizedShrinkablesGenerator.java
@@ -5,6 +5,7 @@ import java.util.logging.*;
 import java.util.stream.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.random.*;
 import net.jqwik.api.support.*;
 import net.jqwik.engine.*;
 import net.jqwik.engine.properties.arbitraries.*;
@@ -20,7 +21,7 @@ public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator
 	public static RandomizedShrinkablesGenerator forParameters(
 		List<MethodParameter> parameters,
 		ArbitraryResolver arbitraryResolver,
-		Random random,
+		JqwikRandom random,
 		int genSize,
 		EdgeCasesMode edgeCasesMode
 	) {
@@ -36,7 +37,7 @@ public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator
 			edgeCasesMode,
 			edgeCasesTotal,
 			calculateBaseToEdgeCaseRatio(listOfEdgeCases, genSize),
-			random.nextLong()
+			random.split().saveState()
 		);
 	}
 
@@ -159,8 +160,8 @@ public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator
 	private final EdgeCasesMode edgeCasesMode;
 	private final int edgeCasesTotal;
 	private final int baseToEdgeCaseRatio;
-	private final long baseRandomSeed;
-	private Random random;
+	private final JqwikRandomState seed;
+	private JqwikRandom random;
 
 	private boolean allEdgeCasesGenerated = false;
 	private int edgeCasesTried = 0;
@@ -171,15 +172,15 @@ public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator
 		EdgeCasesMode edgeCasesMode,
 		int edgeCasesTotal,
 		int baseToEdgeCaseRatio,
-		long baseRandomSeed
+		JqwikRandomState seed
 	) {
 		this.randomGenerator = randomGenerator;
 		this.edgeCasesGenerator = edgeCasesGenerator;
 		this.edgeCasesMode = edgeCasesMode;
 		this.edgeCasesTotal = edgeCasesTotal;
 		this.baseToEdgeCaseRatio = baseToEdgeCaseRatio;
-		this.baseRandomSeed = baseRandomSeed;
-		this.random = SourceOfRandomness.newRandom(baseRandomSeed);
+		this.seed = seed;
+		this.random = SourceOfRandomness.newRandom(seed);
 	}
 
 	@Override
@@ -225,10 +226,10 @@ public class RandomizedShrinkablesGenerator implements ForAllParametersGenerator
 
 	@Override
 	public void reset() {
-		random = SourceOfRandomness.newRandom(baseRandomSeed);
+		random = SourceOfRandomness.newRandom(seed);
 	}
 
-	private boolean shouldGenerateEdgeCase(Random localRandom) {
+	private boolean shouldGenerateEdgeCase(JqwikRandom localRandom) {
 		return localRandom.nextInt(baseToEdgeCaseRatio + 1) == 0;
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/combinations/CombineArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/combinations/CombineArbitrary.java
@@ -102,7 +102,7 @@ public class CombineArbitrary<R> implements Arbitrary<R> {
 		};
 	}
 
-	private List<Shrinkable<Object>> generateShrinkables(List<RandomGenerator<Object>> generators, Random random) {
+	private List<Shrinkable<Object>> generateShrinkables(List<RandomGenerator<Object>> generators, JqwikRandom random) {
 		List<Shrinkable<Object>> list = new ArrayList<>();
 		for (RandomGenerator<Object> generator : generators) {
 			list.add(generator.next(random));

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/BiasedNumericGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/BiasedNumericGenerator.java
@@ -18,7 +18,7 @@ class BiasedNumericGenerator implements RandomNumericGenerator {
 	}
 
 	@Override
-	public BigInteger next(Random random) {
+	public BigInteger next(JqwikRandom random) {
 		return partitionedGenerator.next(random);
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/BigUniformNumericGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/BigUniformNumericGenerator.java
@@ -1,7 +1,6 @@
 package net.jqwik.engine.properties.arbitraries.randomized;
 
 import java.math.*;
-import java.util.*;
 
 import net.jqwik.api.*;
 
@@ -20,9 +19,9 @@ class BigUniformNumericGenerator implements RandomDistribution.RandomNumericGene
 	}
 
 	@Override
-	public BigInteger next(Random random) {
+	public BigInteger next(JqwikRandom random) {
 		while (true) {
-			BigInteger rawValue = new BigInteger(bits, random);
+			BigInteger rawValue = new BigInteger(bits, random.asJdkRandom());
 			BigInteger value = rawValue.add(min);
 			if (value.compareTo(min) >= 0 && value.compareTo(max) <= 0) {
 				return value;

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/CollectGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/CollectGenerator.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.properties.shrinking.*;
 
 public class CollectGenerator<T> implements RandomGenerator<List<T>> {
@@ -16,7 +17,7 @@ public class CollectGenerator<T> implements RandomGenerator<List<T>> {
 	}
 
 	@Override
-	public Shrinkable<List<T>> next(Random random) {
+	public Shrinkable<List<T>> next(JqwikRandom random) {
 		List<T> base = new ArrayList<>();
 		List<Shrinkable<T>> shrinkables = new ArrayList<>();
 		for (int i = 0; i < 10000; i++) {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/ConstantFunctionGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/ConstantFunctionGenerator.java
@@ -5,6 +5,7 @@ import java.util.function.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.Tuple.*;
+import net.jqwik.api.JqwikRandom;
 
 public class ConstantFunctionGenerator<F, R> extends AbstractFunctionGenerator<F, R> {
 
@@ -17,7 +18,7 @@ public class ConstantFunctionGenerator<F, R> extends AbstractFunctionGenerator<F
 	}
 
 	@Override
-	public Shrinkable<F> next(Random random) {
+	public Shrinkable<F> next(JqwikRandom random) {
 		Shrinkable<R> shrinkableConstant = resultGenerator.next(random);
 		return createConstantFunction(shrinkableConstant);
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/ContainerGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/ContainerGenerator.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.properties.*;
 
 import static net.jqwik.engine.properties.UniquenessChecker.*;
@@ -14,10 +15,10 @@ class ContainerGenerator<T, C> implements RandomGenerator<C> {
 	private final int minSize;
 	private final long maxUniqueElements;
 	private final Collection<FeatureExtractor<T>> uniquenessExtractors;
-	private final Function<Random, Integer> sizeGenerator;
+	private final Function<JqwikRandom, Integer> sizeGenerator;
 	private final long maxAttempts;
 
-	private static Function<Random, Integer> sizeGenerator(
+	private static Function<JqwikRandom, Integer> sizeGenerator(
 		int minSize,
 		int maxSize,
 		int genSize,
@@ -51,7 +52,7 @@ class ContainerGenerator<T, C> implements RandomGenerator<C> {
 	}
 
 	@Override
-	public Shrinkable<C> next(Random random) {
+	public Shrinkable<C> next(JqwikRandom random) {
 		int listSize = sizeGenerator.apply(random);
 		List<Shrinkable<T>> listOfShrinkables = new ArrayList<>();
 
@@ -93,15 +94,15 @@ class ContainerGenerator<T, C> implements RandomGenerator<C> {
 			// If we started generating with no duplicates, and then realized we can't generate enough unique elements,
 			// then the list becomes skewed: unique elements go first
 			// We shuffle the list to allow other constellations (e.g. list unique-most elements starting with non-unique ones)
-			Collections.shuffle(listOfShrinkables, random);
+			Collections.shuffle(listOfShrinkables, random.asJdkRandom());
 		}
 		return createShrinkable.apply(listOfShrinkables);
 	}
 
 	private Shrinkable<T> nextUntilAccepted(
-		Random random,
+		JqwikRandom random,
 		Collection<T> existingValues,
-		Function<Random, Shrinkable<T>> fetchShrinkable,
+		Function<JqwikRandom, Shrinkable<T>> fetchShrinkable,
 		boolean noDuplicates
 	) {
 		for (int i = 0; i < maxAttempts; i++) {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/FilteredGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/FilteredGenerator.java
@@ -1,9 +1,9 @@
 package net.jqwik.engine.properties.arbitraries.randomized;
 
-import java.util.*;
 import java.util.function.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.properties.shrinking.*;
 
 public class FilteredGenerator<T> implements RandomGenerator<T> {
@@ -18,7 +18,7 @@ public class FilteredGenerator<T> implements RandomGenerator<T> {
 	}
 
 	@Override
-	public Shrinkable<T> next(Random random) {
+	public Shrinkable<T> next(JqwikRandom random) {
 		return nextUntilAccepted(random, toFilter::next);
 	}
 
@@ -27,7 +27,7 @@ public class FilteredGenerator<T> implements RandomGenerator<T> {
 		return String.format("Filtering [%s]", toFilter);
 	}
 
-	private Shrinkable<T> nextUntilAccepted(Random random, Function<Random, Shrinkable<T>> fetchShrinkable) {
+	private Shrinkable<T> nextUntilAccepted(JqwikRandom random, Function<JqwikRandom, Shrinkable<T>> fetchShrinkable) {
 		for (int i = 0; i < maxMisses; i++) {
 			Shrinkable<T> value = fetchShrinkable.apply(random);
 			if (filterPredicate.test(value.value())) {

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/FrequencyGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/FrequencyGenerator.java
@@ -3,6 +3,7 @@ package net.jqwik.engine.properties.arbitraries.randomized;
 import java.util.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.properties.shrinking.*;
 import net.jqwik.engine.support.*;
 
@@ -13,7 +14,7 @@ class FrequencyGenerator<T> extends ChooseRandomlyByFrequency<T> implements Rand
 	}
 
 	@Override
-	public Shrinkable<T> next(Random random) {
+	public Shrinkable<T> next(JqwikRandom random) {
 		return new ChooseValueShrinkable<>(apply(random), possibleValues());
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/FunctionGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/FunctionGenerator.java
@@ -8,6 +8,7 @@ import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.Tuple.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.*;
 import net.jqwik.engine.support.*;
 
@@ -24,11 +25,11 @@ public class FunctionGenerator<F, R> extends AbstractFunctionGenerator<F, R> {
 	}
 
 	@Override
-	public Shrinkable<F> next(Random random) {
+	public Shrinkable<F> next(JqwikRandom random) {
 		return new ShrinkableFunction(createFunction(random));
 	}
 
-	private F createFunction(Random random) {
+	private F createFunction(JqwikRandom random) {
 		long baseSeed = random.nextLong();
 		InvocationHandler handler = (proxy, method, args) -> {
 			if (JqwikReflectionSupport.isEqualsMethod(method)) {
@@ -44,7 +45,7 @@ public class FunctionGenerator<F, R> extends AbstractFunctionGenerator<F, R> {
 				return handleDefaultMethod(proxy, method, args);
 			}
 			return conditionalResult(args).orElseGet(() -> {
-				Random randomForArgs = SourceOfRandomness.newRandom(seedForArgs(baseSeed, args));
+				JqwikRandom randomForArgs = SourceOfRandomness.newRandom(seedForArgs(baseSeed, args));
 				Shrinkable<R> shrinkableResult = resultGenerator.next(randomForArgs);
 				storeLastResult(shrinkableResult);
 				return new Object[]{shrinkableResult.value()};

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/GaussianNumericGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/GaussianNumericGenerator.java
@@ -3,6 +3,7 @@ package net.jqwik.engine.properties.arbitraries.randomized;
 import java.math.*;
 import java.util.*;
 
+import net.jqwik.api.*;
 import net.jqwik.api.RandomDistribution.*;
 
 public class GaussianNumericGenerator implements RandomNumericGenerator {
@@ -23,9 +24,10 @@ public class GaussianNumericGenerator implements RandomNumericGenerator {
 	}
 
 	@Override
-	public BigInteger next(Random random) {
+	public BigInteger next(JqwikRandom random) {
+		Random rnd = random.asJdkRandom();
 		while (true) {
-			double gaussianFactor = random.nextGaussian() / borderSigma;
+			double gaussianFactor = rnd.nextGaussian() / borderSigma;
 			BigInteger value = center;
 			if (gaussianFactor < 0.0 && leftRange.compareTo(BigInteger.ZERO) > 0) {
 				BigDecimal bigDecimalLeft = new BigDecimal(leftRange).multiply(BigDecimal.valueOf(gaussianFactor).abs());

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/IgnoreExceptionGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/IgnoreExceptionGenerator.java
@@ -1,9 +1,9 @@
 package net.jqwik.engine.properties.arbitraries.randomized;
 
-import java.util.*;
 import java.util.function.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.properties.shrinking.*;
 
 import static net.jqwik.engine.support.JqwikExceptionSupport.*;
@@ -19,11 +19,11 @@ public class IgnoreExceptionGenerator<T> implements RandomGenerator<T> {
 	}
 
 	@Override
-	public Shrinkable<T> next(final Random random) {
+	public Shrinkable<T> next(final JqwikRandom random) {
 		return new IgnoreExceptionShrinkable<>(nextUntilAccepted(random, base::next), exceptionTypes);
 	}
 
-	private Shrinkable<T> nextUntilAccepted(Random random, Function<Random, Shrinkable<T>> fetchShrinkable) {
+	private Shrinkable<T> nextUntilAccepted(JqwikRandom random, Function<JqwikRandom, Shrinkable<T>> fetchShrinkable) {
 		for (int i = 0; i < 10000; i++) {
 			try {
 				Shrinkable<T> next = fetchShrinkable.apply(random);

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/InjectDuplicatesGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/InjectDuplicatesGenerator.java
@@ -4,6 +4,7 @@ import java.util.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.lifecycle.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.*;
 
 public class InjectDuplicatesGenerator<T> implements RandomGenerator<T> {
@@ -23,12 +24,12 @@ public class InjectDuplicatesGenerator<T> implements RandomGenerator<T> {
 	}
 
 	@Override
-	public Shrinkable<T> next(Random random) {
+	public Shrinkable<T> next(JqwikRandom random) {
 		long seed = chooseSeed(random);
 		return base.next(SourceOfRandomness.newRandom(seed));
 	}
 
-	long chooseSeed(Random random) {
+	long chooseSeed(JqwikRandom random) {
 		List<Long> previousSeeds = previousSeedsStore.get();
 		if (!previousSeeds.isEmpty()) {
 			if (random.nextDouble() <= duplicateProbability) {
@@ -40,7 +41,7 @@ public class InjectDuplicatesGenerator<T> implements RandomGenerator<T> {
 		return seed;
 	}
 
-	private long randomPreviousSeed(Store<List<Long>> previousSeeds, Random random) {
+	private long randomPreviousSeed(Store<List<Long>> previousSeeds, JqwikRandom random) {
 		int index = random.nextInt(previousSeeds.get().size());
 		return previousSeeds.get().get(index);
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/RandomGenerators.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/RandomGenerators.java
@@ -34,7 +34,7 @@ public class RandomGenerators {
 		};
 	}
 
-	public static <U> U chooseValue(List<U> values, Random random) {
+	public static <U> U chooseValue(List<U> values, JqwikRandom random) {
 		int index = random.nextInt(values.size());
 		return values.get(index);
 	}
@@ -91,7 +91,7 @@ public class RandomGenerators {
 	public static <T> RandomGenerator<List<T>> shuffle(List<T> values) {
 		return random -> {
 			List<T> clone = new ArrayList<>(values);
-			Collections.shuffle(clone, random);
+			Collections.shuffle(clone, random.asJdkRandom());
 			return Shrinkable.unshrinkable(clone);
 		};
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/SizeGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/SizeGenerator.java
@@ -1,7 +1,6 @@
 package net.jqwik.engine.properties.arbitraries.randomized;
 
 import java.math.*;
-import java.util.*;
 import java.util.function.*;
 
 import net.jqwik.api.*;
@@ -11,14 +10,14 @@ class SizeGenerator {
 	private SizeGenerator() {
 	}
 
-	static Function<Random, Integer> create(int minSize, int maxSize, int genSize, RandomDistribution distribution) {
+	static Function<JqwikRandom, Integer> create(int minSize, int maxSize, int genSize, RandomDistribution distribution) {
 		if (distribution != null) {
 			return sizeGeneratorWithDistribution(minSize, maxSize, genSize, distribution);
 		}
 		return sizeGeneratorWithCutoff(minSize, maxSize, genSize);
 	}
 
-	private static Function<Random, Integer> sizeGeneratorWithDistribution(
+	private static Function<JqwikRandom, Integer> sizeGeneratorWithDistribution(
 		int minSize,
 		int maxSize,
 		int genSize,
@@ -33,7 +32,7 @@ class SizeGenerator {
 		return random -> generator.next(random).intValueExact();
 	}
 
-	private static Function<Random, Integer> sizeGeneratorWithCutoff(int minSize, int maxSize, int genSize) {
+	private static Function<JqwikRandom, Integer> sizeGeneratorWithCutoff(int minSize, int maxSize, int genSize) {
 		int cutoffSize = cutoffSize(minSize, maxSize, genSize);
 		if (cutoffSize >= maxSize)
 			return random -> randomSize(random, minSize, maxSize);
@@ -59,7 +58,7 @@ class SizeGenerator {
 		return Math.min(offset + minSize, maxSize);
 	}
 
-	private static int randomSize(Random random, int minSize, int maxSize) {
+	private static int randomSize(JqwikRandom random, int minSize, int maxSize) {
 		int range = maxSize - minSize;
 		return random.nextInt(range + 1) + minSize;
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/SmallUniformNumericGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/SmallUniformNumericGenerator.java
@@ -1,7 +1,6 @@
 package net.jqwik.engine.properties.arbitraries.randomized;
 
 import java.math.*;
-import java.util.*;
 
 import net.jqwik.api.*;
 
@@ -16,7 +15,7 @@ class SmallUniformNumericGenerator implements RandomDistribution.RandomNumericGe
 	}
 
 	@Override
-	public BigInteger next(Random random) {
+	public BigInteger next(JqwikRandom random) {
 		int bound = Math.abs(max - min) + 1;
 		int value = random.nextInt(bound >= 0 ? bound : Integer.MAX_VALUE) + min;
 		return BigInteger.valueOf(value);

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/WithEdgeCasesGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/randomized/WithEdgeCasesGenerator.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.engine.properties.*;
 
 class WithEdgeCasesGenerator<T> implements RandomGenerator<T> {
@@ -19,7 +20,7 @@ class WithEdgeCasesGenerator<T> implements RandomGenerator<T> {
 	}
 
 	@Override
-	public Shrinkable<T> next(final Random random) {
+	public Shrinkable<T> next(final JqwikRandom random) {
 		if (random.nextInt(baseToEdgeCaseRatio) == 0) {
 			return edgeCasesGenerator.next(random);
 		} else {

--- a/engine/src/main/java/net/jqwik/engine/properties/shrinking/FlatMappedShrinkable.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/shrinking/FlatMappedShrinkable.java
@@ -5,6 +5,7 @@ import java.util.function.*;
 import java.util.stream.*;
 
 import net.jqwik.api.*;
+import net.jqwik.api.random.*;
 import net.jqwik.api.support.*;
 import net.jqwik.engine.*;
 import net.jqwik.engine.support.*;
@@ -18,7 +19,7 @@ public class FlatMappedShrinkable<T, U> implements Shrinkable<U> {
 		Shrinkable<T> toMap,
 		Function<T, Arbitrary<U>> toArbitraryMapper,
 		int genSize,
-		long randomSeed,
+		JqwikRandomState randomSeed,
 		boolean withEmbeddedEdgeCases
 	) {
 		this(toMap, t -> {
@@ -27,7 +28,7 @@ public class FlatMappedShrinkable<T, U> implements Shrinkable<U> {
 		}, randomSeed);
 	}
 
-	public FlatMappedShrinkable(Shrinkable<T> toMap, Function<T, RandomGenerator<U>> toGeneratorMapper, long randomSeed) {
+	public FlatMappedShrinkable(Shrinkable<T> toMap, Function<T, RandomGenerator<U>> toGeneratorMapper, JqwikRandomState randomSeed) {
 		this(toMap, t -> toGeneratorMapper.apply(t).next(SourceOfRandomness.newRandom(randomSeed)));
 	}
 

--- a/engine/src/main/java/net/jqwik/engine/properties/state/DefaultChainArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/state/DefaultChainArbitrary.java
@@ -23,9 +23,9 @@ public class DefaultChainArbitrary<T> extends TypedCloneable implements ChainArb
 	public RandomGenerator<Chain<T>> generator(int genSize) {
 		final int effectiveMaxTransformations =
 			this.maxTransformations != Integer.MIN_VALUE ? this.maxTransformations : (int) Math.max(Math.round(Math.sqrt(genSize)), 10);
-		Function<Random, Transformation<T>> transformationGenerator = new ChooseRandomlyByFrequency<>(weightedTransformations);
+		Function<JqwikRandom, Transformation<T>> transformationGenerator = new ChooseRandomlyByFrequency<>(weightedTransformations);
 		return random -> new ShrinkableChain<>(
-			random.nextLong(),
+			random.split().saveState(),
 			initialSupplier,
 			transformationGenerator,
 			changeDetectorSupplier,

--- a/engine/src/main/java/net/jqwik/engine/properties/stateful/ActionSequenceGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/stateful/ActionSequenceGenerator.java
@@ -1,8 +1,7 @@
 package net.jqwik.engine.properties.stateful;
 
-import java.util.*;
-
 import net.jqwik.api.*;
+import net.jqwik.api.JqwikRandom;
 import net.jqwik.api.stateful.*;
 
 class ActionSequenceGenerator<M> implements RandomGenerator<ActionSequence<M>> {
@@ -17,7 +16,7 @@ class ActionSequenceGenerator<M> implements RandomGenerator<ActionSequence<M>> {
 	}
 
 	@Override
-	public Shrinkable<ActionSequence<M>> next(Random random) {
+	public Shrinkable<ActionSequence<M>> next(JqwikRandom random) {
 		ActionGenerator<M> actionGenerator = new RandomActionGenerator<>(actionArbitrary, genSize, random);
 		return new ShrinkableActionSequence<>(actionGenerator, maxSize, ShrinkingDistance.of(maxSize));
 	}

--- a/engine/src/main/java/net/jqwik/engine/properties/stateful/RandomActionGenerator.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/stateful/RandomActionGenerator.java
@@ -10,10 +10,10 @@ class RandomActionGenerator<T> implements ActionGenerator<T> {
 	private static final int MAX_TRIES = 1000;
 
 	private final RandomGenerator<Action<T>> randomGenerator;
-	private final Random random;
+	private final JqwikRandom random;
 	private List<Shrinkable<Action<T>>> shrinkableActions = new ArrayList<>();
 
-	RandomActionGenerator(Arbitrary<Action<T>> actionArbitrary, int genSize, Random random) {
+	RandomActionGenerator(Arbitrary<Action<T>> actionArbitrary, int genSize, JqwikRandom random) {
 		this.random = random;
 		this.randomGenerator = actionArbitrary.generator(genSize);
 	}

--- a/engine/src/main/java/net/jqwik/engine/providers/JqwikRandomArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/JqwikRandomArbitraryProvider.java
@@ -1,0 +1,22 @@
+package net.jqwik.engine.providers;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.JqwikRandom;
+import net.jqwik.api.providers.ArbitraryProvider;
+import net.jqwik.api.providers.TypeUsage;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class JqwikRandomArbitraryProvider implements ArbitraryProvider {
+	@Override
+	public boolean canProvideFor(TypeUsage targetType) {
+		return targetType.isOfType(JqwikRandom.class);
+	}
+
+	@Override
+	public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
+		return Collections.singleton(Arbitraries.randoms());
+	}
+}

--- a/engine/src/main/java/net/jqwik/engine/providers/JqwikRandomStateArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/JqwikRandomStateArbitraryProvider.java
@@ -1,0 +1,24 @@
+package net.jqwik.engine.providers;
+
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.JqwikRandom;
+import net.jqwik.api.providers.ArbitraryProvider;
+import net.jqwik.api.providers.TypeUsage;
+import net.jqwik.api.random.*;
+
+import java.util.Collections;
+import java.util.Random;
+import java.util.Set;
+
+public class JqwikRandomStateArbitraryProvider implements ArbitraryProvider {
+	@Override
+	public boolean canProvideFor(TypeUsage targetType) {
+		return targetType.isOfType(JqwikRandomState.class);
+	}
+
+	@Override
+	public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
+		return Collections.singleton(Arbitraries.randoms().map(random -> random.split().saveState()));
+	}
+}

--- a/engine/src/main/java/net/jqwik/engine/providers/RandomArbitraryProvider.java
+++ b/engine/src/main/java/net/jqwik/engine/providers/RandomArbitraryProvider.java
@@ -13,6 +13,6 @@ public class RandomArbitraryProvider implements ArbitraryProvider {
 
 	@Override
 	public Set<Arbitrary<?>> provideFor(TypeUsage targetType, SubtypeProvider subtypeProvider) {
-		return Collections.singleton(Arbitraries.randoms());
+		return Collections.singleton(Arbitraries.randoms().map(JqwikRandom::asJdkRandom));
 	}
 }

--- a/engine/src/main/java/net/jqwik/engine/random/BaseRandomState.java
+++ b/engine/src/main/java/net/jqwik/engine/random/BaseRandomState.java
@@ -1,0 +1,23 @@
+package net.jqwik.engine.random;
+
+import net.jqwik.api.random.*;
+
+import org.apache.commons.rng.*;
+import org.apache.commons.rng.simple.*;
+
+public abstract class BaseRandomState implements JqwikRandomState {
+	private final RandomSource algorithm;
+
+	protected BaseRandomState(RandomSource algorithm) {
+		this.algorithm = algorithm;
+	}
+
+	@Override
+	public RandomSource getAlgorithm() {
+		return algorithm;
+	}
+
+	abstract public RandomProviderState getState();
+	
+	abstract public RestorableUniformRandomProvider createGenerator();
+}

--- a/engine/src/main/java/net/jqwik/engine/random/InMemoryRandomState.java
+++ b/engine/src/main/java/net/jqwik/engine/random/InMemoryRandomState.java
@@ -1,0 +1,25 @@
+package net.jqwik.engine.random;
+
+import org.apache.commons.rng.*;
+import org.apache.commons.rng.simple.*;
+
+public class InMemoryRandomState extends BaseRandomState {
+	private final RandomProviderState state;
+
+	protected InMemoryRandomState(RandomSource algorithm, RandomProviderState state) {
+		super(algorithm);
+		this.state = state;
+	}
+
+	@Override
+	public RandomProviderState getState() {
+		return state;
+	}
+
+	@Override
+	public RestorableUniformRandomProvider createGenerator() {
+		RestorableUniformRandomProvider provider = getAlgorithm().create();
+		provider.restoreState(state);
+		return provider;
+	}
+}

--- a/engine/src/main/java/net/jqwik/engine/random/JqwikRandomImpl.java
+++ b/engine/src/main/java/net/jqwik/engine/random/JqwikRandomImpl.java
@@ -1,0 +1,59 @@
+package net.jqwik.engine.random;
+
+import net.jqwik.api.JqwikRandom;
+import net.jqwik.api.random.JqwikRandomState;
+
+import org.apache.commons.rng.*;
+import org.apache.commons.rng.simple.*;
+
+import java.util.*;
+
+public class JqwikRandomImpl implements JqwikRandom {
+	private final RandomSource algorithm;
+	private final RestorableUniformRandomProvider delegate;
+
+	public JqwikRandomImpl(RandomSource algorithm, RestorableUniformRandomProvider delegate) {
+		this.algorithm = algorithm;
+		this.delegate = delegate;
+	}
+
+	@Override
+	public long nextLong() {
+		return delegate.nextLong();
+	}
+	
+	@Override
+	public JqwikRandom split(UniformRandomProvider source) {
+		if (delegate instanceof SplittableUniformRandomProvider) {
+			RestorableUniformRandomProvider next = (RestorableUniformRandomProvider) ((SplittableUniformRandomProvider) delegate).split();
+			return new JqwikRandomImpl(algorithm, next);
+		}
+		throw new IllegalStateException("Base random source should be splittable, actual is " + delegate.getClass().getSimpleName());
+	}
+
+	@Override
+	public JqwikRandom jump() {
+		if (delegate instanceof JumpableUniformRandomProvider) {
+			RestorableUniformRandomProvider next = (RestorableUniformRandomProvider) ((JumpableUniformRandomProvider) delegate).jump();
+			return new JqwikRandomImpl(algorithm, next);
+		}
+		throw new IllegalStateException("Base random source should be jumpable, actual is " + delegate.getClass().getSimpleName());
+	}
+
+	@Override
+	public JqwikRandomState saveState() {
+		return new InMemoryRandomState(algorithm, delegate.saveState());
+	}
+
+	@Override
+	public void restoreState(JqwikRandomState state) {
+		if (state.getAlgorithm() != algorithm) {
+			throw new IllegalArgumentException(
+				"Cannot restore state from different algorithm. Current: " + algorithm + ", new: " + state.getAlgorithm()
+			);
+		}
+		if (state instanceof BaseRandomState) {
+			delegate.restoreState(((BaseRandomState) state).getState());
+		}
+	}
+}

--- a/engine/src/main/java/net/jqwik/engine/random/SeedBasedRandomState.java
+++ b/engine/src/main/java/net/jqwik/engine/random/SeedBasedRandomState.java
@@ -1,0 +1,41 @@
+package net.jqwik.engine.random;
+
+import net.jqwik.api.random.*;
+
+import org.apache.commons.rng.*;
+import org.apache.commons.rng.simple.*;
+import org.jetbrains.annotations.*;
+
+import java.nio.*;
+
+public class SeedBasedRandomState extends BaseRandomState {
+	private final byte[] seed;
+	private @Nullable RandomProviderState state;
+	
+	public SeedBasedRandomState(RandomSource algorithm, byte[] seed) {
+		super(algorithm);
+		this.seed = seed;
+	}
+
+	public byte[] getSeed() {
+		return seed;
+	}
+
+	@Override
+	public RestorableUniformRandomProvider createGenerator() {
+		return getAlgorithm().create(seed);
+	}
+
+	@Override
+	public RandomProviderState getState() {
+		RandomProviderState state;
+		synchronized (this) {
+		    state = this.state;
+			if (state == null) {
+				state = createGenerator().saveState();
+				this.state = state;
+			}
+		}
+		return state;
+	}
+}

--- a/engine/src/main/java/net/jqwik/engine/support/ChooseRandomlyByFrequency.java
+++ b/engine/src/main/java/net/jqwik/engine/support/ChooseRandomlyByFrequency.java
@@ -5,7 +5,7 @@ import java.util.function.*;
 
 import net.jqwik.api.*;
 
-public class ChooseRandomlyByFrequency<T> implements Function<Random, T> {
+public class ChooseRandomlyByFrequency<T> implements Function<JqwikRandom, T> {
 
 	private int[] upperBounds;
 	private int size = 0;
@@ -61,7 +61,7 @@ public class ChooseRandomlyByFrequency<T> implements Function<Random, T> {
 		return valuesToChooseFrom.get(i);
 	}
 
-	public T apply(Random random) {
+	public T apply(JqwikRandom random) {
 		return choose(random.nextInt(size));
 	}
 }

--- a/engine/src/main/resources/META-INF/services/net.jqwik.api.providers.ArbitraryProvider
+++ b/engine/src/main/resources/META-INF/services/net.jqwik.api.providers.ArbitraryProvider
@@ -10,4 +10,6 @@ net.jqwik.engine.providers.BigIntegerArbitraryProvider
 net.jqwik.engine.providers.BigDecimalArbitraryProvider
 net.jqwik.engine.providers.StringArbitraryProvider
 net.jqwik.engine.providers.RandomArbitraryProvider
+net.jqwik.engine.providers.JqwikRandomArbitraryProvider
+net.jqwik.engine.providers.JqwikRandomStateArbitraryProvider
 net.jqwik.engine.providers.ObjectArbitraryProvider

--- a/engine/src/test/java/experiments/SharedArbitraryExperiments.java
+++ b/engine/src/test/java/experiments/SharedArbitraryExperiments.java
@@ -6,6 +6,7 @@ import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.lifecycle.*;
+import net.jqwik.api.JqwikRandom;
 
 // Edge cases and (probably) exhaustive generation does not really work with this approach
 // Maybe it can be made to work with even more hacking.
@@ -110,7 +111,7 @@ class SharedArbitrary<T> implements Arbitrary<T> {
 		}
 
 		@Override
-		public Shrinkable<T> next(Random random) {
+		public Shrinkable<T> next(JqwikRandom random) {
 			if (store.get() != null) {
 				return new ShrinkableRef();
 			}

--- a/engine/src/test/java/net/jqwik/UseArbitrariesOutsideJqwikTests.java
+++ b/engine/src/test/java/net/jqwik/UseArbitrariesOutsideJqwikTests.java
@@ -74,7 +74,6 @@ class UseArbitrariesOutsideJqwikTests {
 		Arbitrary<Integer> ints = Arbitraries.integers().between(-1000, 1000);
 		Arbitrary<Integer> intsWithDuplicates = ints.injectDuplicates(0.5);
 
-		Random random = new Random();
 		// Try 20 times because it fails sometimes due to enhanced probability of no duplicates
 		for (int i = 0; i < 20; i++) {
 

--- a/engine/src/test/java/net/jqwik/api/ArbitrariesRecursiveTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArbitrariesRecursiveTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class ArbitrariesRecursiveTests {
 
 	@Example
-	void minMaxDepthRecursion(@ForAll Random random) {
+	void minMaxDepthRecursion(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> lists = Arbitraries.recursive(
 			() -> Arbitraries.create(ArrayList::new),
 			list -> {
@@ -35,7 +35,7 @@ class ArbitrariesRecursiveTests {
 	}
 
 	@Example
-	void fixedDepthRecursion(@ForAll Random random) {
+	void fixedDepthRecursion(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> lists = Arbitraries.recursive(
 			() -> Arbitraries.create(ArrayList::new),
 			list -> {
@@ -54,7 +54,7 @@ class ArbitrariesRecursiveTests {
 	}
 
 	@Example
-	void zeroDepthRecursion(@ForAll Random random) {
+	void zeroDepthRecursion(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> lists = Arbitraries.recursive(
 			() -> Arbitraries.create(ArrayList::new),
 			list -> {
@@ -185,7 +185,7 @@ class ArbitrariesRecursiveTests {
 	class ShrinkingTests {
 
 		@Property
-		void fixedDepthRecursion(@ForAll Random random) {
+		void fixedDepthRecursion(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> base = Arbitraries.integers().between(0, 10);
 			Arbitrary<Integer> integer = Arbitraries.recursive(
 				() -> base,
@@ -200,7 +200,7 @@ class ArbitrariesRecursiveTests {
 		}
 
 		@Property
-		void minMaxDepthRecursion(@ForAll Random random) {
+		void minMaxDepthRecursion(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> base = Arbitraries.integers().between(1, 10);
 			Arbitrary<Integer> integer = Arbitraries.recursive(
 				() -> Arbitraries.just(0),
@@ -215,7 +215,7 @@ class ArbitrariesRecursiveTests {
 		}
 
 		@Property
-		void complexShrinking(@ForAll Random random) {
+		void complexShrinking(@ForAll JqwikRandom random) {
 			Arbitrary<String> sentences = sentences(20);
 
 			TestingFalsifier<String> max10words = sentence -> sentence.split(" ").length <= 10;

--- a/engine/src/test/java/net/jqwik/api/ArbitrariesTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArbitrariesTests.java
@@ -34,7 +34,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void randomValues(@ForAll Random random) {
+	void randomValues(@ForAll JqwikRandom random) {
 		Arbitrary<String> stringArbitrary = Arbitraries.randomValue(r -> Integer.toString(r.nextInt(10)));
 		RandomGenerator<String> generator = stringArbitrary.generator(1);
 		checkAllGenerated(generator, random, value -> Integer.parseInt(value) < 10);
@@ -42,7 +42,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void fromGenerator(@ForAll Random random) {
+	void fromGenerator(@ForAll JqwikRandom random) {
 		Arbitrary<String> stringArbitrary =
 			Arbitraries.fromGenerator(r -> Shrinkable.unshrinkable(Integer.toString(r.nextInt(10))));
 		RandomGenerator<String> generator = stringArbitrary.generator(1);
@@ -50,7 +50,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofValues(@ForAll Random random) {
+	void ofValues(@ForAll JqwikRandom random) {
 		Arbitrary<String> stringArbitrary = Arbitraries.of("1", "hallo", "test");
 		RandomGenerator<String> generator = stringArbitrary.generator(1);
 		checkAllGenerated(generator, random, (String value) -> Arrays.asList("1", "hallo", "test").contains(value));
@@ -58,7 +58,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofValueList(@ForAll Random random) {
+	void ofValueList(@ForAll JqwikRandom random) {
 		List<String> valueList = Arrays.asList("1", "hallo", "test");
 		Arbitrary<String> stringArbitrary = Arbitraries.of(valueList);
 		RandomGenerator<String> generator = stringArbitrary.generator(1);
@@ -67,7 +67,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofNonNullableValueList(@ForAll Random random) {
+	void ofNonNullableValueList(@ForAll JqwikRandom random) {
 		// TODO: Replace with List.of("a", "b") when moving to JDK >= 11
 		List<String> valueList = new ArrayList<String>() {
 			@Override
@@ -87,7 +87,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofValueSet(@ForAll Random random) {
+	void ofValueSet(@ForAll JqwikRandom random) {
 		Set<String> valueSet = new HashSet<>(Arrays.asList("1", "hallo", "test"));
 		Arbitrary<String> stringArbitrary = Arbitraries.of(valueSet);
 		RandomGenerator<String> generator = stringArbitrary.generator(1);
@@ -96,7 +96,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofSuppliers(@ForAll Random random) {
+	void ofSuppliers(@ForAll JqwikRandom random) {
 		Arbitrary<List<String>> listArbitrary = Arbitraries.ofSuppliers(ArrayList::new, ArrayList::new);
 		RandomGenerator<List<String>> generator = listArbitrary.generator(1);
 		assertAllGenerated(generator, random, (List<String> value) -> {
@@ -106,7 +106,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofSupplierList(@ForAll Random random) {
+	void ofSupplierList(@ForAll JqwikRandom random) {
 		@SuppressWarnings("unchecked")
 		Supplier<List<String>>[] suppliers = new Supplier[]{ArrayList::new, ArrayList::new};
 		List<Supplier<List<String>>> supplierList = Arrays.asList(suppliers);
@@ -119,7 +119,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofSupplierSet(@ForAll Random random) {
+	void ofSupplierSet(@ForAll JqwikRandom random) {
 		@SuppressWarnings("unchecked")
 		Supplier<List<String>>[] suppliers = new Supplier[]{ArrayList::new, ArrayList::new};
 		Set<Supplier<List<String>>> supplierList = new HashSet<>(Arrays.asList(suppliers));
@@ -132,7 +132,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void ofEnum(@ForAll Random random) {
+	void ofEnum(@ForAll JqwikRandom random) {
 		Arbitrary<MyEnum> enumArbitrary = Arbitraries.of(MyEnum.class);
 		RandomGenerator<MyEnum> generator = enumArbitrary.generator(1);
 		checkAllGenerated(generator, random, (MyEnum value) -> Arrays.asList(MyEnum.values()).contains(value));
@@ -140,7 +140,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void just(@ForAll Random random) {
+	void just(@ForAll JqwikRandom random) {
 		Arbitrary<String> constant = Arbitraries.just("hello");
 		assertAllGenerated(constant.generator(1000), random, value -> {
 			assertThat(value).isEqualTo("hello");
@@ -148,7 +148,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void forType(@ForAll Random random) {
+	void forType(@ForAll JqwikRandom random) {
 		TypeArbitrary<Person> constant = Arbitraries.forType(Person.class);
 		assertAllGenerated(constant.generator(1000), random, value -> {
 			assertThat(value).isInstanceOf(Person.class);
@@ -158,27 +158,27 @@ class ArbitrariesTests {
 	@Group
 	class Randoms {
 		@Example
-		void randoms(@ForAll Random random) {
-			Arbitrary<Random> randomArbitrary = Arbitraries.randoms();
-			RandomGenerator<Random> generator = randomArbitrary.generator(1);
-			checkAllGenerated(generator, random, (Random value) -> value.nextInt(100) < 100);
+		void randoms(@ForAll JqwikRandom random) {
+			Arbitrary<JqwikRandom> randomArbitrary = Arbitraries.randoms();
+			RandomGenerator<JqwikRandom> generator = randomArbitrary.generator(1);
+			checkAllGenerated(generator, random, (JqwikRandom value) -> value.nextInt(100) < 100);
 		}
 
 		// GenericGenerationProperties cannot be used due to different equality semantics of Random
 
 		@Property(tries = 100)
 		void sameRandomWillGenerateSameValueOnFreshGenerator(
-			@ForAll Random random,
+			@ForAll JqwikRandom random,
 			@ForAll @IntRange(min = 1, max = 10000) int genSize,
 			@ForAll boolean withEdgeCases
 		) {
 			long seed = random.nextLong();
-			Arbitrary<Random> arbitrary = Arbitraries.randoms();
+			Arbitrary<JqwikRandom> arbitrary = Arbitraries.randoms();
 
-			RandomGenerator<Random> gen1 = arbitrary.generator(genSize, withEdgeCases);
-			Random valueA = gen1.next(SourceOfRandomness.newRandom(seed)).value();
-			RandomGenerator<Random> gen2 = arbitrary.generator(genSize, withEdgeCases);
-			Random valueB = gen2.next(SourceOfRandomness.newRandom(seed)).value();
+			RandomGenerator<JqwikRandom> gen1 = arbitrary.generator(genSize, withEdgeCases);
+			JqwikRandom valueA = gen1.next(SourceOfRandomness.newRandom(seed)).value();
+			RandomGenerator<JqwikRandom> gen2 = arbitrary.generator(genSize, withEdgeCases);
+			JqwikRandom valueB = gen2.next(SourceOfRandomness.newRandom(seed)).value();
 			assertThat(valueA.nextLong()).isEqualTo(valueB.nextLong());
 		}
 
@@ -187,14 +187,14 @@ class ArbitrariesTests {
 			@ForAll @IntRange(min = 1, max = 10000) int genSize,
 			@ForAll boolean withEdgeCases
 		) {
-			Arbitrary<Random> arbitrary1 = Arbitraries.randoms();
-			Arbitrary<Random> arbitrary2 = Arbitraries.randoms();
+			Arbitrary<JqwikRandom> arbitrary1 = Arbitraries.randoms();
+			Arbitrary<JqwikRandom> arbitrary2 = Arbitraries.randoms();
 
-			RandomGenerator<Random> gen1 = Memoize.memoizedGenerator(
+			RandomGenerator<JqwikRandom> gen1 = Memoize.memoizedGenerator(
 				arbitrary1, genSize, withEdgeCases,
 				() -> arbitrary1.generator(genSize, withEdgeCases)
 			);
-			RandomGenerator<Random> gen2 = Memoize.memoizedGenerator(
+			RandomGenerator<JqwikRandom> gen2 = Memoize.memoizedGenerator(
 				arbitrary2, genSize, withEdgeCases,
 				() -> arbitrary2.generator(genSize, withEdgeCases)
 			);
@@ -203,20 +203,20 @@ class ArbitrariesTests {
 
 		@Property(tries = 100)
 		void sameRandomWillGenerateSameValueOnMemoizedGenerator(
-			@ForAll Random randomToGenerateValue,
+			@ForAll JqwikRandom randomToGenerateValue,
 			@ForAll @IntRange(min = 1, max = 10000) int genSize,
 			@ForAll boolean withEdgeCases
 		) {
-			Arbitrary<Random> arbitrary1 = Arbitraries.randoms();
-			Arbitrary<Random> arbitrary2 = Arbitraries.randoms();
+			Arbitrary<JqwikRandom> arbitrary1 = Arbitraries.randoms();
+			Arbitrary<JqwikRandom> arbitrary2 = Arbitraries.randoms();
 
 			long seedToGenerateValue = randomToGenerateValue.nextLong();
 
-			RandomGenerator<Random> gen1 = Memoize.memoizedGenerator(arbitrary1, genSize, withEdgeCases, () -> arbitrary1.generator(genSize, withEdgeCases));
-			RandomGenerator<Random> gen2 = Memoize.memoizedGenerator(arbitrary2, genSize, withEdgeCases, () -> arbitrary2.generator(genSize, withEdgeCases));
+			RandomGenerator<JqwikRandom> gen1 = Memoize.memoizedGenerator(arbitrary1, genSize, withEdgeCases, () -> arbitrary1.generator(genSize, withEdgeCases));
+			RandomGenerator<JqwikRandom> gen2 = Memoize.memoizedGenerator(arbitrary2, genSize, withEdgeCases, () -> arbitrary2.generator(genSize, withEdgeCases));
 
-			Random valueA = gen1.next(SourceOfRandomness.newRandom(seedToGenerateValue)).value();
-			Random valueB = gen2.next(SourceOfRandomness.newRandom(seedToGenerateValue)).value();
+			JqwikRandom valueA = gen1.next(SourceOfRandomness.newRandom(seedToGenerateValue)).value();
+			JqwikRandom valueB = gen2.next(SourceOfRandomness.newRandom(seedToGenerateValue)).value();
 			assertThat(valueA.nextLong()).isEqualTo(valueB.nextLong());
 		}
 
@@ -281,7 +281,7 @@ class ArbitrariesTests {
 	}
 
 	@Example
-	void create_regenerates_objects_on_each_call(@ForAll Random random) {
+	void create_regenerates_objects_on_each_call(@ForAll JqwikRandom random) {
 		Arbitrary<AtomicInteger> constant = Arbitraries.create(() -> new AtomicInteger(42));
 		AtomicInteger[] previous = new AtomicInteger[]{new AtomicInteger(42)};
 		assertAllGenerated(constant.generator(1000, true), random, value -> {
@@ -296,13 +296,13 @@ class ArbitrariesTests {
 	@Label("shuffle(..)")
 	class Shuffle {
 		@Example
-		void varArgsValues(@ForAll Random random) {
+		void varArgsValues(@ForAll JqwikRandom random) {
 			Arbitrary<List<Integer>> shuffled = Arbitraries.shuffle(1, 2, 3);
 			assertPermutations(shuffled, random);
 		}
 
 		@Example
-		void noValues(@ForAll Random random) {
+		void noValues(@ForAll JqwikRandom random) {
 			Arbitrary<List<Integer>> shuffled = Arbitraries.shuffle();
 			assertAllGenerated(
 				shuffled.generator(1000),
@@ -312,12 +312,12 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void listOfValues(@ForAll Random random) {
+		void listOfValues(@ForAll JqwikRandom random) {
 			Arbitrary<List<Integer>> shuffled = Arbitraries.shuffle(Arrays.asList(1, 2, 3));
 			assertPermutations(shuffled, random);
 		}
 
-		private void assertPermutations(Arbitrary<List<Integer>> shuffled, Random random) {
+		private void assertPermutations(Arbitrary<List<Integer>> shuffled, JqwikRandom random) {
 			assertAtLeastOneGeneratedOf(
 				shuffled.generator(1000),
 				random,
@@ -336,7 +336,7 @@ class ArbitrariesTests {
 	class OneOf {
 
 		@Example
-		void choosesOneOfManyArbitraries(@ForAll Random random) {
+		void choosesOneOfManyArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> one = Arbitraries.of(1);
 			Arbitrary<Integer> two = Arbitraries.of(2);
 			Arbitrary<Integer> threeToFive = Arbitraries.of(3, 4, 5);
@@ -351,7 +351,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void choosesOneOfDifferentCovariantTypes(@ForAll Random random) {
+		void choosesOneOfDifferentCovariantTypes(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> ones = Arbitraries.of(1);
 			Arbitrary<String> twos = Arbitraries.of("2");
 
@@ -386,7 +386,7 @@ class ArbitrariesTests {
 	class FrequencyOf {
 
 		@Example
-		void choosesOneOfManyAccordingToFrequency(@ForAll Random random) {
+		void choosesOneOfManyAccordingToFrequency(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> one = Arbitraries.of(1);
 			Arbitrary<Integer> two = Arbitraries.of(2);
 
@@ -424,7 +424,7 @@ class ArbitrariesTests {
 	class Lazy {
 
 		@Example
-		void lazy(@ForAll Random random) {
+		void lazy(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> samples = Arbitraries.lazy(() -> new OrderedArbitraryForTesting<>(1, 2, 3));
 
 			assertGeneratedExactly(samples.generator(1000), random, 1, 2, 3, 1);
@@ -432,7 +432,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void recursiveLazy(@ForAll Random random) {
+		void recursiveLazy(@ForAll JqwikRandom random) {
 			Arbitrary<Tree> trees = trees();
 			checkAllGenerated(
 				trees.generator(1000, true),
@@ -548,13 +548,13 @@ class ArbitrariesTests {
 	class Frequency {
 
 		@Example
-		void onePair(@ForAll Random random) {
+		void onePair(@ForAll JqwikRandom random) {
 			Arbitrary<String> one = Arbitraries.frequency(Tuple.of(1, "a"));
 			checkAllGenerated(one.generator(1000), random, value -> {return value.equals("a");});
 		}
 
 		@Property(tries = 10)
-		void twoEqualPairs(@ForAll Random random) {
+		void twoEqualPairs(@ForAll JqwikRandom random) {
 			Arbitrary<String> one = Arbitraries.frequency(Tuple.of(1, "a"), Tuple.of(1, "b"));
 			Map<String, Long> counts = count(one.generator(1000, true), 1000, random);
 			assertThat(counts.get("a") > 200).isTrue();
@@ -562,14 +562,14 @@ class ArbitrariesTests {
 		}
 
 		@Property(tries = 10)
-		void twoUnequalPairs(@ForAll Random random) {
+		void twoUnequalPairs(@ForAll JqwikRandom random) {
 			Arbitrary<String> one = Arbitraries.frequency(Tuple.of(1, "a"), Tuple.of(10, "b"));
 			Map<String, Long> counts = count(one.generator(1000, true), 1000, random);
 			assertThat(counts.get("a")).isLessThan(counts.get("b"));
 		}
 
 		@Property(tries = 10)
-		void fourUnequalPairs(@ForAll Random random) {
+		void fourUnequalPairs(@ForAll JqwikRandom random) {
 			Arbitrary<String> one = Arbitraries.frequency(
 				Tuple.of(1, "a"),
 				Tuple.of(5, "b"),
@@ -593,28 +593,28 @@ class ArbitrariesTests {
 	@Label("defaultFor(..)")
 	class DefaultFor {
 		@Example
-		void simpleType(@ForAll Random random) {
+		void simpleType(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integerArbitrary = Arbitraries.defaultFor(Integer.class);
 			checkAllGenerated(integerArbitrary.generator(1000), random, Objects::nonNull);
 		}
 
 		@SuppressWarnings("rawtypes")
 		@Example
-		void parameterizedType(@ForAll Random random) {
+		void parameterizedType(@ForAll JqwikRandom random) {
 			Arbitrary<List> list = Arbitraries.defaultFor(List.class, String.class);
 			checkAllGenerated(list.generator(1000), random, List.class::isInstance);
 		}
 
 		@SuppressWarnings("rawtypes")
 		@Example
-		void moreThanOneDefault(@ForAll Random random) {
+		void moreThanOneDefault(@ForAll JqwikRandom random) {
 			Arbitrary<Collection> collections = Arbitraries.defaultFor(Collection.class, String.class);
 			TestingSupport.checkAtLeastOneGenerated(collections.generator(1000), random, List.class::isInstance);
 			TestingSupport.checkAtLeastOneGenerated(collections.generator(1000), random, Set.class::isInstance);
 		}
 
 		@Example
-		void defaultForWithTypeUsage(@ForAll Random random) throws NoSuchMethodException {
+		void defaultForWithTypeUsage(@ForAll JqwikRandom random) throws NoSuchMethodException {
 			class Container {
 				void method(@Size(3) List<Integer> intList) {}
 			}
@@ -668,14 +668,14 @@ class ArbitrariesTests {
 	@Label("chars()")
 	class Chars {
 		@Example
-		void charsDefault(@ForAll Random random) {
+		void charsDefault(@ForAll JqwikRandom random) {
 			Arbitrary<Character> arbitrary = Arbitraries.chars();
 			RandomGenerator<Character> generator = arbitrary.generator(1);
 			checkAllGenerated(generator, random, Objects::nonNull);
 		}
 
 		@Example
-		void chars(@ForAll Random random) {
+		void chars(@ForAll JqwikRandom random) {
 			Arbitrary<Character> arbitrary = Arbitraries.chars().range('a', 'd');
 			RandomGenerator<Character> generator = arbitrary.generator(1);
 			List<Character> allowedChars = Arrays.asList('a', 'b', 'c', 'd');
@@ -688,7 +688,7 @@ class ArbitrariesTests {
 	@Label("strings()")
 	class Strings {
 		@Example
-		void string(@ForAll Random random) {
+		void string(@ForAll JqwikRandom random) {
 			Arbitrary<String> stringArbitrary = Arbitraries.strings()
 														   .withCharRange('a', 'd')
 														   .ofMinLength(0).ofMaxLength(5);
@@ -697,7 +697,7 @@ class ArbitrariesTests {
 		}
 
 		@Property(tries = 20)
-		void stringWithFixedLength(@ForAll @IntRange(min = 1, max = 10) int size, @ForAll Random random) {
+		void stringWithFixedLength(@ForAll @IntRange(min = 1, max = 10) int size, @ForAll JqwikRandom random) {
 			Arbitrary<String> stringArbitrary = Arbitraries.strings()
 														   .withCharRange('a', 'a')
 														   .ofMinLength(size).ofMaxLength(size);
@@ -707,7 +707,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void stringFromCharset(@ForAll Random random) {
+		void stringFromCharset(@ForAll JqwikRandom random) {
 			char[] validChars = new char[]{'a', 'b', 'c', 'd'};
 			Arbitrary<String> stringArbitrary = Arbitraries.strings()
 														   .withChars(validChars)
@@ -736,14 +736,14 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void shorts(@ForAll Random random) {
+		void shorts(@ForAll JqwikRandom random) {
 			Arbitrary<Short> enumArbitrary = Arbitraries.shorts();
 			RandomGenerator<Short> generator = enumArbitrary.generator(100);
 			checkAllGenerated(generator, random, (Short value) -> value >= Short.MIN_VALUE && value <= Short.MAX_VALUE);
 		}
 
 		@Example
-		void shortsMinsAndMaxes(@ForAll Random random) {
+		void shortsMinsAndMaxes(@ForAll JqwikRandom random) {
 			Arbitrary<Short> enumArbitrary = Arbitraries.shorts().between((short) -10, (short) 10);
 			RandomGenerator<Short> generator = enumArbitrary.generator(100);
 
@@ -753,14 +753,14 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void bytes(@ForAll Random random) {
+		void bytes(@ForAll JqwikRandom random) {
 			Arbitrary<Byte> enumArbitrary = Arbitraries.bytes();
 			RandomGenerator<Byte> generator = enumArbitrary.generator(1);
 			checkAllGenerated(generator, random, (Byte value) -> value >= Byte.MIN_VALUE && value <= Byte.MAX_VALUE);
 		}
 
 		@Example
-		void bytesMinsAndMaxes(@ForAll Random random) {
+		void bytesMinsAndMaxes(@ForAll JqwikRandom random) {
 			Arbitrary<Byte> enumArbitrary = Arbitraries.bytes().between((byte) -10, (byte) 10);
 			RandomGenerator<Byte> generator = enumArbitrary.generator(1);
 
@@ -770,14 +770,14 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void integerMinsAndMaxesWithEdgeCases(@ForAll Random random) {
+		void integerMinsAndMaxesWithEdgeCases(@ForAll JqwikRandom random) {
 			RandomGenerator<Integer> generator = Arbitraries.integers().generator(1, true);
 			TestingSupport.checkAtLeastOneGenerated(generator, random, value -> value == Integer.MIN_VALUE);
 			TestingSupport.checkAtLeastOneGenerated(generator, random, value -> value == Integer.MAX_VALUE);
 		}
 
 		@Example
-		void integersInt(@ForAll Random random) {
+		void integersInt(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> intArbitrary = Arbitraries.integers().between(-10, 10);
 			RandomGenerator<Integer> generator = intArbitrary.generator(10);
 
@@ -787,14 +787,14 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void longMinsAndMaxesWithEdgeCases(@ForAll Random random) {
+		void longMinsAndMaxesWithEdgeCases(@ForAll JqwikRandom random) {
 			RandomGenerator<Long> generator = Arbitraries.longs().generator(1, true);
 			TestingSupport.checkAtLeastOneGenerated(generator, random, value -> value == Long.MIN_VALUE);
 			TestingSupport.checkAtLeastOneGenerated(generator, random, value -> value == Long.MAX_VALUE);
 		}
 
 		@Example
-		void integersLong(@ForAll Random random) {
+		void integersLong(@ForAll JqwikRandom random) {
 			Arbitrary<Long> longArbitrary = Arbitraries.longs().between(-100L, 100L);
 			RandomGenerator<Long> generator = longArbitrary.generator(1000);
 
@@ -804,7 +804,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void bigIntegers(@ForAll Random random) {
+		void bigIntegers(@ForAll JqwikRandom random) {
 			Arbitrary<BigInteger> bigIntegerArbitrary = Arbitraries.bigIntegers().between(valueOf(-100L), valueOf(100L));
 			RandomGenerator<BigInteger> generator = bigIntegerArbitrary.generator(1);
 
@@ -819,7 +819,7 @@ class ArbitrariesTests {
 		}
 
 		@Property(tries = 10)
-		void bigIntegersWithUniformDistribution(@ForAll Random random) {
+		void bigIntegersWithUniformDistribution(@ForAll JqwikRandom random) {
 			Arbitrary<BigInteger> bigIntegerArbitrary =
 				Arbitraries.bigIntegers()
 						   .between(valueOf(-1000L), valueOf(1000L))
@@ -836,7 +836,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void integralEdgeCasesAreGenerated(@ForAll Random random) {
+		void integralEdgeCasesAreGenerated(@ForAll JqwikRandom random) {
 			BigInteger min = valueOf(Integer.MIN_VALUE);
 			BigInteger max = valueOf(Integer.MAX_VALUE);
 			BigInteger shrinkingTarget = valueOf(101);
@@ -870,7 +870,7 @@ class ArbitrariesTests {
 	@Label("bigDecimals()")
 	class BigDecimals {
 		@Example
-		void bigDecimalsWithEdgeCases(@ForAll Random random) {
+		void bigDecimalsWithEdgeCases(@ForAll JqwikRandom random) {
 			Arbitrary<BigDecimal> arbitrary = Arbitraries.bigDecimals()
 														 .between(BigDecimal.valueOf(-100.0), BigDecimal.valueOf(100.0))
 														 .ofScale(2)
@@ -889,7 +889,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void bigDecimalsLessOrEqual(@ForAll Random random) {
+		void bigDecimalsLessOrEqual(@ForAll JqwikRandom random) {
 			BigDecimal max = BigDecimal.valueOf(10);
 			Arbitrary<BigDecimal> arbitrary = Arbitraries.bigDecimals().lessOrEqual(max);
 			RandomGenerator<BigDecimal> generator = arbitrary.generator(1);
@@ -897,7 +897,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void bigDecimalsLessThan(@ForAll Random random) {
+		void bigDecimalsLessThan(@ForAll JqwikRandom random) {
 			BigDecimal max = BigDecimal.valueOf(10);
 			Arbitrary<BigDecimal> arbitrary = Arbitraries.bigDecimals().lessThan(max).ofScale(1);
 			RandomGenerator<BigDecimal> generator = arbitrary.generator(1);
@@ -905,7 +905,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void bigDecimalsGreaterOrEqual(@ForAll Random random) {
+		void bigDecimalsGreaterOrEqual(@ForAll JqwikRandom random) {
 			BigDecimal min = BigDecimal.valueOf(10);
 			Arbitrary<BigDecimal> arbitrary = Arbitraries.bigDecimals().greaterOrEqual(min);
 			RandomGenerator<BigDecimal> generator = arbitrary.generator(1);
@@ -913,7 +913,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void bigDecimalsGreaterThan(@ForAll Random random) {
+		void bigDecimalsGreaterThan(@ForAll JqwikRandom random) {
 			BigDecimal min = BigDecimal.valueOf(10);
 			Arbitrary<BigDecimal> arbitrary = Arbitraries.bigDecimals().greaterThan(min).ofScale(1);
 			RandomGenerator<BigDecimal> generator = arbitrary.generator(1);
@@ -929,7 +929,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void bigDecimalsWithBordersExcludedAndEdgeCases(@ForAll Random random) {
+		void bigDecimalsWithBordersExcludedAndEdgeCases(@ForAll JqwikRandom random) {
 			Range<BigDecimal> range = Range.of(BigDecimal.valueOf(-10.0), false, BigDecimal.valueOf(10.0), false);
 			Arbitrary<BigDecimal> arbitrary = Arbitraries.bigDecimals()
 														 .between(range.min, range.minIncluded, range.max, range.maxIncluded)
@@ -944,7 +944,7 @@ class ArbitrariesTests {
 		}
 
 		@Property(tries = 10)
-		void bigDecimalsWithUniformDistribution(@ForAll Random random) {
+		void bigDecimalsWithUniformDistribution(@ForAll JqwikRandom random) {
 			Range<BigDecimal> range = Range.of(BigDecimal.valueOf(-1000.0), BigDecimal.valueOf(1000.0));
 			Arbitrary<BigDecimal> arbitrary = Arbitraries.bigDecimals()
 														 .between(range.min, range.max)
@@ -968,7 +968,7 @@ class ArbitrariesTests {
 	class GenericTypes {
 
 		@Example
-		void optional(@ForAll Random random) {
+		void optional(@ForAll JqwikRandom random) {
 			Arbitrary<String> stringArbitrary = Arbitraries.of("one", "two");
 			Arbitrary<Optional<String>> optionalArbitrary = stringArbitrary.optional();
 
@@ -980,7 +980,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void optionalWithProbability(@ForAll Random random) {
+		void optionalWithProbability(@ForAll JqwikRandom random) {
 			Arbitrary<String> stringArbitrary = Arbitraries.of("one", "two");
 			Arbitrary<Optional<String>> optionalArbitrary = stringArbitrary.optional(0.9);
 
@@ -992,7 +992,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void entry(@ForAll Random random) {
+		void entry(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> keys = Arbitraries.integers().between(1, 10);
 			Arbitrary<String> values = Arbitraries.strings().alpha().ofLength(5);
 
@@ -1017,7 +1017,7 @@ class ArbitrariesTests {
 	@Group
 	class SubsetOf {
 		@Example
-		void subsetOf(@ForAll Random random) {
+		void subsetOf(@ForAll JqwikRandom random) {
 			SetArbitrary<String> subsets = Arbitraries.subsetOf("One", "Two", "Three").ofMinSize(1);
 			assertAllGenerated(subsets, random, value -> {
 				assertThat(value).isInstanceOf(Set.class);
@@ -1026,7 +1026,7 @@ class ArbitrariesTests {
 		}
 
 		@Example
-		void subsetOfListOfValues(@ForAll Random random) {
+		void subsetOfListOfValues(@ForAll JqwikRandom random) {
 			List<String> values = Arrays.asList("One", "Two", "Three", "One");
 			SetArbitrary<String> subsets = Arbitraries.subsetOf(values).ofMinSize(1);
 			assertAllGenerated(subsets, random, value -> {
@@ -1036,7 +1036,7 @@ class ArbitrariesTests {
 		}
 	}
 
-	private void assertGeneratedString(RandomGenerator<String> generator, Random random, int minLength, int maxLength) {
+	private void assertGeneratedString(RandomGenerator<String> generator, JqwikRandom random, int minLength, int maxLength) {
 		checkAllGenerated(generator, random, value -> value.length() >= minLength && value.length() <= maxLength);
 		List<Character> allowedChars = Arrays.asList('a', 'b', 'c', 'd');
 		checkAllGenerated(

--- a/engine/src/test/java/net/jqwik/api/ArbitraryIgnoreExceptionsTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArbitraryIgnoreExceptionsTests.java
@@ -22,7 +22,7 @@ class ArbitraryIgnoreExceptionsTests {
 
 
 	@Example
-	void ignoreIllegalArgumentException(@ForAll Random random) {
+	void ignoreIllegalArgumentException(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			new OrderedArbitraryForTesting<>(1, 2, 3, 4, 5)
 				.map(anInt -> {
@@ -41,7 +41,7 @@ class ArbitraryIgnoreExceptionsTests {
 	}
 
 	@Example
-	void ignoreMultipleExceptions(@ForAll Random random) {
+	void ignoreMultipleExceptions(@ForAll JqwikRandom random) {
 
 		Arbitrary<Integer> arbitrary =
 			new OrderedArbitraryForTesting<>(1, 2, 3, 4, 5, 6, 7, 8, 9)
@@ -68,7 +68,7 @@ class ArbitraryIgnoreExceptionsTests {
 	}
 
 	@Example
-	void ignoreSubtypeOfException(@ForAll Random random) {
+	void ignoreSubtypeOfException(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			new OrderedArbitraryForTesting<>(1, 2, 3, 4, 5)
 				.map(anInt -> {
@@ -87,7 +87,7 @@ class ArbitraryIgnoreExceptionsTests {
 	}
 
 	@Example
-	void failIfFilterWillDiscard10000ValuesInARow(@ForAll Random random) {
+	void failIfFilterWillDiscard10000ValuesInARow(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			new OrderedArbitraryForTesting<>(1, 2, 3, 4, 5)
 				.map(anInt -> {
@@ -123,7 +123,7 @@ class ArbitraryIgnoreExceptionsTests {
 	class Shrinking {
 
 		@Property(tries = 10)
-		void singleException(@ForAll Random random) {
+		void singleException(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary =
 				Arbitraries.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 						   .map(i -> {
@@ -140,7 +140,7 @@ class ArbitraryIgnoreExceptionsTests {
 
 		@SuppressWarnings("unchecked")
 		@Property(tries = 10)
-		void severalExceptions(@ForAll Random random) {
+		void severalExceptions(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary =
 				Arbitraries.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 						   .map(i -> {

--- a/engine/src/test/java/net/jqwik/api/ArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArbitraryTests.java
@@ -22,7 +22,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class ArbitraryTests {
 
 	@Example
-	void generatorWithoutEdgeCases(@ForAll Random random) {
+	void generatorWithoutEdgeCases(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary = Arbitraries.integers().between(-1000, 1000);
 		RandomGenerator<Integer> generator = arbitrary.generator(10, false);
 		checkAllGenerated(generator, random, i -> i >= -1000 && i <= 1000);
@@ -55,7 +55,7 @@ class ArbitraryTests {
 	}
 
 	@Property(tries = 100)
-	void nullsWithProbability50Percent(@ForAll Random random) {
+	void nullsWithProbability50Percent(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> ints = Arbitraries.integers().between(-1000, 1000);
 		Arbitrary<Integer> intsWithNulls = ints.injectNull(0.5);
 
@@ -136,7 +136,7 @@ class ArbitraryTests {
 	class GeneratorWithEmbeddedEdgeCases {
 
 		@Example
-		void generatorWithEdgeCases(@ForAll Random random) {
+		void generatorWithEdgeCases(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = Arbitraries.integers().between(-1000, 1000);
 			RandomGenerator<Integer> generator = arbitrary.generator(10, true);
 
@@ -241,7 +241,7 @@ class ArbitraryTests {
 	@Group
 	class Filtering {
 		@Example
-		void filterInteger(@ForAll Random random) {
+		void filterInteger(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = new OrderedArbitraryForTesting<>(1, 2, 3, 4, 5);
 			Arbitrary<Integer> filtered = arbitrary.filter(anInt -> anInt % 2 != 0);
 			RandomGenerator<Integer> generator = filtered.generator(10, true);
@@ -253,7 +253,7 @@ class ArbitraryTests {
 		}
 
 		@Example
-		void failIfFilterWillDiscard10000ValuesInARow(@ForAll Random random) {
+		void failIfFilterWillDiscard10000ValuesInARow(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = Arbitraries.of(1, 2, 3, 4, 5);
 			Arbitrary<Integer> filtered = arbitrary.filter(anInt -> false);
 			RandomGenerator<Integer> generator = filtered.generator(10, true);
@@ -305,7 +305,7 @@ class ArbitraryTests {
 	class Mapping {
 
 		@Example
-		void mapIntegerToString(@ForAll Random random) {
+		void mapIntegerToString(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = new OrderedArbitraryForTesting<>(1, 2, 3, 4, 5);
 			Arbitrary<String> mapped = arbitrary.map(anInt -> "value=" + anInt);
 			RandomGenerator<String> generator = mapped.generator(10, true);
@@ -320,7 +320,7 @@ class ArbitraryTests {
 
 		// To ensure optimization of just(value).map(..) works
 		@Example
-		void mapJust(@ForAll Random random) {
+		void mapJust(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = Arbitraries.just(5);
 			Arbitrary<String> mapped = arbitrary.map(anInt -> "value=" + anInt);
 
@@ -335,7 +335,7 @@ class ArbitraryTests {
 	class FlatMapping {
 
 		@Example
-		void flatMapIntegerToString(@ForAll Random random) {
+		void flatMapIntegerToString(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = new OrderedArbitraryForTesting<>(1, 2, 3, 4, 5);
 			Arbitrary<String> mapped = arbitrary.flatMap(anInt -> Arbitraries.strings() //
 																			 .withCharRange('a', 'e') //
@@ -358,7 +358,7 @@ class ArbitraryTests {
 
 		// To ensure optimization of just(value).flatMap(..) works
 		@Example
-		void flatMapJust(@ForAll Random random) {
+		void flatMapJust(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = Arbitraries.just(5);
 			Arbitrary<String> mapped = arbitrary.flatMap(anInt -> Arbitraries.strings()
 																			 .withCharRange('a', 'e')
@@ -382,7 +382,7 @@ class ArbitraryTests {
 	class Combination {
 
 		@Example
-		void generateCombination(@ForAll Random random) {
+		void generateCombination(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> a1 = new OrderedArbitraryForTesting<>(1, 2, 3);
 			Arbitrary<Integer> a2 = new OrderedArbitraryForTesting<>(4, 5, 6);
 			Arbitrary<String> combined = Combinators.combine(a1, a2).as((i1, i2) -> i1 + ":" + i2);
@@ -400,7 +400,7 @@ class ArbitraryTests {
 	class Collect {
 
 		@Example
-		void collectList(@ForAll Random random) {
+		void collectList(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integers = Arbitraries.integers().between(1, 3);
 			Arbitrary<List<Integer>> collected = integers.collect(list -> sum(list) >= 10);
 			RandomGenerator<List<Integer>> generator = collected.generator(10, true);
@@ -412,7 +412,7 @@ class ArbitraryTests {
 		}
 
 		@Example
-		void collectListWillThrowExceptionIfTooBig(@ForAll Random random) {
+		void collectListWillThrowExceptionIfTooBig(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integers = Arbitraries.integers().between(1, 3);
 			Arbitrary<List<Integer>> collected = integers.collect(list -> sum(list) < 0);
 			RandomGenerator<List<Integer>> generator = collected.generator(10, true);
@@ -450,7 +450,7 @@ class ArbitraryTests {
 	class Duplicates {
 
 		@Property(tries = 100)
-		void duplicatesWith20Percent(@ForAll Random random) {
+		void duplicatesWith20Percent(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> ints = Arbitraries.integers().between(-1000, 1000);
 			Arbitrary<Integer> intsWithDuplicates = ints.injectDuplicates(0.2);
 			ListArbitrary<Integer> arbitrary = intsWithDuplicates.list().ofSize(100);
@@ -466,7 +466,7 @@ class ArbitraryTests {
 		}
 
 		@Property(tries = 100)
-		void duplicatesWith50Percent(@ForAll Random random) {
+		void duplicatesWith50Percent(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> ints = Arbitraries.integers().between(-1000, 1000);
 			Arbitrary<Integer> intsWithDuplicates = ints.injectDuplicates(0.5);
 			ListArbitrary<Integer> arbitrary = intsWithDuplicates.list().ofSize(100);
@@ -482,7 +482,7 @@ class ArbitraryTests {
 		}
 
 		@Property(tries = 100)
-		void duplicatesWith100Percent(@ForAll Random random) {
+		void duplicatesWith100Percent(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> ints = Arbitraries.integers().between(-1000, 1000);
 			Arbitrary<Integer> intsWithDuplicates = ints.injectDuplicates(1.0);
 			ListArbitrary<Integer> arbitrary = intsWithDuplicates.list().ofSize(100);

--- a/engine/src/test/java/net/jqwik/api/ArrayArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/ArrayArbitraryTests.java
@@ -19,7 +19,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class ArrayArbitraryTests {
 
 	@Example
-	void array(@ForAll Random random) {
+	void array(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		ArrayArbitrary<Integer, Integer[]> arrayArbitrary = integerArbitrary.array(Integer[].class).ofMinSize(2).ofMaxSize(5);
 
@@ -32,7 +32,7 @@ class ArrayArbitraryTests {
 	}
 
 	@Example
-	void arrayOfSupertype(@ForAll Random random) {
+	void arrayOfSupertype(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		ArrayArbitrary<Integer, Object[]> arrayArbitrary = integerArbitrary.array(Object[].class).ofMinSize(2).ofMaxSize(5);
 
@@ -51,7 +51,7 @@ class ArrayArbitraryTests {
 	}
 
 	@Example
-	void arrayForComponentClass(@ForAll Random random) {
+	void arrayForComponentClass(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		ArrayArbitrary<Integer, Integer[]> arrayArbitrary =
 			DefaultArrayArbitrary.forComponentType(integerArbitrary, Integer.class).ofMinSize(2).ofMaxSize(5);
@@ -66,7 +66,7 @@ class ArrayArbitraryTests {
 
 	@Example
 	@StatisticsReport(onFailureOnly = true)
-	void withSizeDistribution(@ForAll Random random) {
+	void withSizeDistribution(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 		ArrayArbitrary<Integer, Integer[]> arbitrary =
 			integerArbitrary.array(Integer[].class).ofMaxSize(100)
@@ -87,7 +87,7 @@ class ArrayArbitraryTests {
 	}
 
 	@Example
-	void reduceArray(@ForAll Random random) {
+	void reduceArray(@ForAll JqwikRandom random) {
 		ArrayArbitrary<Integer, Integer[]> arrayArbitrary =
 			Arbitraries.integers().between(1, 5).array(Integer[].class).ofMinSize(1).ofMaxSize(10);
 
@@ -104,7 +104,7 @@ class ArrayArbitraryTests {
 	}
 
 	@Example
-	void arrayOfPrimitiveType(@ForAll Random random) {
+	void arrayOfPrimitiveType(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		ArrayArbitrary<Integer, int[]> arrayArbitrary = integerArbitrary.array(int[].class).ofMinSize(0).ofMaxSize(5);
 
@@ -117,7 +117,7 @@ class ArrayArbitraryTests {
 	}
 
 	@Example
-	void uniquenessConstraint(@ForAll Random random) {
+	void uniquenessConstraint(@ForAll JqwikRandom random) {
 		ArrayArbitrary<Integer, Integer[]> listArbitrary =
 			Arbitraries.integers().between(1, 1000).array(Integer[].class).ofMaxSize(20)
 					   .uniqueElements(i -> i % 100);
@@ -130,7 +130,7 @@ class ArrayArbitraryTests {
 	}
 
 	@Example
-	void uniqueElements(@ForAll Random random) {
+	void uniqueElements(@ForAll JqwikRandom random) {
 		ArrayArbitrary<Integer, Integer[]> listArbitrary =
 			Arbitraries.integers().between(1, 1000).array(Integer[].class).ofMaxSize(20)
 					   .uniqueElements();
@@ -254,14 +254,14 @@ class ArrayArbitraryTests {
 	class Shrinking {
 
 		@Property
-		void shrinksToEmptyArrayByDefault(@ForAll Random random) {
+		void shrinksToEmptyArrayByDefault(@ForAll JqwikRandom random) {
 			ArrayArbitrary<Integer, Integer[]> arrays = Arbitraries.integers().between(1, 10).array(Integer[].class);
 			Integer[] value = falsifyThenShrink(arrays, random);
 			assertThat(value).isEmpty();
 		}
 
 		@Property
-		void shrinkToMinSize(@ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int min) {
+		void shrinkToMinSize(@ForAll JqwikRandom random, @ForAll @IntRange(min = 1, max = 20) int min) {
 			ArrayArbitrary<Integer, Integer[]> arrays = Arbitraries.integers().between(1, 10).array(Integer[].class).ofMinSize(min);
 			Integer[] value = falsifyThenShrink(arrays, random);
 			assertThat(value).hasSize(min);
@@ -269,7 +269,7 @@ class ArrayArbitraryTests {
 		}
 
 		@Property
-		void shrinkWithUniqueness(@ForAll Random random, @ForAll @IntRange(min = 2, max = 10) int min) {
+		void shrinkWithUniqueness(@ForAll JqwikRandom random, @ForAll @IntRange(min = 2, max = 10) int min) {
 			ArrayArbitrary<Integer, Integer[]> lists =
 				Arbitraries.integers().between(1, 100).array(Integer[].class).ofMinSize(min).ofMaxSize(10)
 						   .uniqueElements(i -> i);

--- a/engine/src/test/java/net/jqwik/api/BuildersTests.java
+++ b/engine/src/test/java/net/jqwik/api/BuildersTests.java
@@ -17,7 +17,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class BuildersTests {
 
 	@Property
-	void plainBuilder(@ForAll Random random) {
+	void plainBuilder(@ForAll JqwikRandom random) {
 		Arbitrary<Person> personArbitrary =
 				Builders
 						.withBuilder(PersonBuilder::new)
@@ -29,7 +29,7 @@ class BuildersTests {
 	}
 
 	@Property
-	void appendingBuilder(@ForAll Random random) {
+	void appendingBuilder(@ForAll JqwikRandom random) {
 		Arbitrary<String> digits = Arbitraries.of("0", "1", "2");
 
 		Arbitrary<String> arbitrary =
@@ -45,7 +45,7 @@ class BuildersTests {
 	}
 
 	@Property
-	void useBuilderMethods(@ForAll Random random) {
+	void useBuilderMethods(@ForAll JqwikRandom random) {
 		Arbitrary<String> name = Arbitraries.strings().alpha().ofLength(10);
 		Arbitrary<Integer> age = Arbitraries.integers().between(0, 15);
 
@@ -62,7 +62,7 @@ class BuildersTests {
 	}
 
 	@Property
-	void useNullableArbitraryInBuilderMethods(@ForAll Random random) {
+	void useNullableArbitraryInBuilderMethods(@ForAll JqwikRandom random) {
 		Arbitrary<String> name = Arbitraries.strings().injectNull(1.0);
 		Arbitrary<Integer> age = Arbitraries.integers().between(0, 15);
 
@@ -79,7 +79,7 @@ class BuildersTests {
 	}
 
 	@Property
-	void useBuilderMethodsWithProbability0and1(@ForAll Random random) {
+	void useBuilderMethodsWithProbability0and1(@ForAll JqwikRandom random) {
 		Arbitrary<String> name = Arbitraries.strings().alpha().ofLength(10);
 		Arbitrary<Integer> age = Arbitraries.integers().between(0, 15);
 
@@ -96,7 +96,7 @@ class BuildersTests {
 	}
 
 	@Example
-	void useBuilderMethodsWithProbabilities(@ForAll Random random) {
+	void useBuilderMethodsWithProbabilities(@ForAll JqwikRandom random) {
 		Arbitrary<String> name = Arbitraries.strings().alpha().ofLength(10);
 		Arbitrary<Integer> age = Arbitraries.integers().between(0, 15);
 
@@ -130,7 +130,7 @@ class BuildersTests {
 	}
 
 	@Property
-	void buildWithoutFunctionUsesIdentityAsDefault(@ForAll Random random) {
+	void buildWithoutFunctionUsesIdentityAsDefault(@ForAll JqwikRandom random) {
 		Arbitrary<Person> personArbitrary =
 			Builders
 				.withBuilder(() -> new Person("john", 42))
@@ -144,7 +144,7 @@ class BuildersTests {
 	}
 
 	@Property
-	void builderIsFreshlyCreatedForEachTry(@ForAll Random random) {
+	void builderIsFreshlyCreatedForEachTry(@ForAll JqwikRandom random) {
 		Arbitrary<String> name = Arbitraries.strings().alpha().ofLength(10);
 
 		Arbitrary<Person> personArbitrary =
@@ -161,7 +161,7 @@ class BuildersTests {
 	}
 
 	@Property
-	void useInSetter(@ForAll Random random) {
+	void useInSetter(@ForAll JqwikRandom random) {
 		Arbitrary<String> name = Arbitraries.strings().alpha().ofLength(10);
 		Arbitrary<Integer> age = Arbitraries.integers().between(0, 15);
 
@@ -182,7 +182,7 @@ class BuildersTests {
 	class Shrinking {
 
 		@Property
-		void shrinkToSmallestValues(@ForAll Random random) {
+		void shrinkToSmallestValues(@ForAll JqwikRandom random) {
 			Arbitrary<String> name = Arbitraries.strings().alpha().ofLength(10);
 			Arbitrary<Integer> age = Arbitraries.integers().between(0, 15);
 
@@ -198,7 +198,7 @@ class BuildersTests {
 		}
 
 		@Property
-		void shrinkMaybeUsesToNotUsed(@ForAll Random random) {
+		void shrinkMaybeUsesToNotUsed(@ForAll JqwikRandom random) {
 			Arbitrary<String> name = Arbitraries.strings().alpha().ofLength(10);
 			Arbitrary<Integer> age = Arbitraries.integers().between(0, 15);
 
@@ -214,7 +214,7 @@ class BuildersTests {
 		}
 
 		@Property
-		void shrinkAllUses(@ForAll Random random) {
+		void shrinkAllUses(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> digits = Arbitraries.integers().between(0, 9);
 
 			Arbitrary<String> arbitrary =
@@ -236,7 +236,7 @@ class BuildersTests {
 		}
 
 		@Property(tries = 5)
-		void shrinkingBigBuilder(@ForAll Random random) {
+		void shrinkingBigBuilder(@ForAll JqwikRandom random) {
 			Builders.BuilderCombinator<Integer[]> combinator = bigBuilder(200);
 			Arbitrary<Integer[]> arbitrary = combinator.build();
 

--- a/engine/src/test/java/net/jqwik/api/CombinatorsTests.java
+++ b/engine/src/test/java/net/jqwik/api/CombinatorsTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.testing.TestingSupport.*;
 
 class CombinatorsTests {
 
-	private final Random random = SourceOfRandomness.current();
+	private final JqwikRandom random = SourceOfRandomness.current();
 
 	@Example
 	void twoArbitrariesCanBeCombined() {
@@ -89,7 +89,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void twoArbitraries(@ForAll Random random) {
+		void twoArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple2<Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree())
 						   .filter((a, b) -> !a.equals(b))
@@ -103,7 +103,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void doubleFilters(@ForAll Random random) {
+		void doubleFilters(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple2<Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree())
 						   .filter((a, b) -> a + b != 2)
@@ -119,7 +119,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void threeArbitraries(@ForAll Random random) {
+		void threeArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple3<Integer, Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree(), oneToThree())
 						   .filter((a, b, c) -> !a.equals(b))
@@ -133,7 +133,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void fourArbitraries(@ForAll Random random) {
+		void fourArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple4<Integer, Integer, Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree(), oneToThree(), oneToThree())
 						   .filter((a, b, c, d) -> !a.equals(b))
@@ -147,7 +147,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void fiveArbitraries(@ForAll Random random) {
+		void fiveArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple5<Integer, Integer, Integer, Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree())
 						   .filter((a, b, c, d, e) -> !a.equals(b))
@@ -161,7 +161,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void sixArbitraries(@ForAll Random random) {
+		void sixArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple6<Integer, Integer, Integer, Integer, Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree())
 						   .filter((a, b, c, d, e, f) -> !a.equals(b))
@@ -175,7 +175,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void sevenArbitraries(@ForAll Random random) {
+		void sevenArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple7<Integer, Integer, Integer, Integer, Integer, Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree())
 						   .filter((a, b, c, d, e, f, g) -> !a.equals(b))
@@ -189,7 +189,7 @@ class CombinatorsTests {
 		}
 
 		@Example
-		void eightArbitraries(@ForAll Random random) {
+		void eightArbitraries(@ForAll JqwikRandom random) {
 			Arbitrary<Tuple8<Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer>> combine =
 				Combinators.combine(oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree(), oneToThree())
 						   .filter((a, b, c, d, e, f, g, h) -> !a.equals(b))

--- a/engine/src/test/java/net/jqwik/api/DoubleArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/DoubleArbitraryTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class DoubleArbitraryTests {
 
 	@Example
-	void doubleMinsAndMaxesWithEdgeCases(@ForAll Random random) {
+	void doubleMinsAndMaxesWithEdgeCases(@ForAll JqwikRandom random) {
 		RandomGenerator<Double> generator = Arbitraries.doubles().generator(1, true);
 		TestingSupport.checkAtLeastOneGenerated(generator, random, value -> value == 0.01);
 		TestingSupport.checkAtLeastOneGenerated(generator, random, value -> value == -0.01);
@@ -23,7 +23,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doubles(@ForAll Random random) {
+	void doubles(@ForAll JqwikRandom random) {
 		Arbitrary<Double> doubleArbitrary = Arbitraries.doubles().between(-10.0, 10.0).ofScale(2);
 		RandomGenerator<Double> generator = doubleArbitrary.generator(1);
 
@@ -37,7 +37,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesWithMaximumRange(@ForAll Random random) {
+	void doublesWithMaximumRange(@ForAll JqwikRandom random) {
 		double min = -Double.MAX_VALUE;
 		Arbitrary<Double> doubleArbitrary = Arbitraries.doubles().between(min, Double.MAX_VALUE).ofScale(2);
 		RandomGenerator<Double> generator = doubleArbitrary.generator(100, true);
@@ -64,7 +64,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesWithBordersExcluded(@ForAll Random random) {
+	void doublesWithBordersExcluded(@ForAll JqwikRandom random) {
 		double min = 1.0;
 		double max = 2.0;
 		Arbitrary<Double> doubleArbitrary = Arbitraries.doubles().between(min, false, max, false).ofScale(1);
@@ -73,7 +73,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesLessThan(@ForAll Random random) {
+	void doublesLessThan(@ForAll JqwikRandom random) {
 		double max = 2.0;
 		Arbitrary<Double> doubleArbitrary = Arbitraries.doubles().lessThan(max).ofScale(0);
 		RandomGenerator<Double> generator = doubleArbitrary.generator(100);
@@ -81,7 +81,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesLessOrEqual(@ForAll Random random) {
+	void doublesLessOrEqual(@ForAll JqwikRandom random) {
 		double max = 2.0;
 		Arbitrary<Double> doubleArbitrary = Arbitraries.doubles().lessOrEqual(max).ofScale(0);
 		RandomGenerator<Double> generator = doubleArbitrary.generator(100);
@@ -89,7 +89,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesGreaterThan(@ForAll Random random) {
+	void doublesGreaterThan(@ForAll JqwikRandom random) {
 		double min = 2.0;
 		Arbitrary<Double> doubleArbitrary = Arbitraries.doubles().greaterThan(min).ofScale(0);
 		RandomGenerator<Double> generator = doubleArbitrary.generator(100);
@@ -97,7 +97,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesGreaterOrEqual(@ForAll Random random) {
+	void doublesGreaterOrEqual(@ForAll JqwikRandom random) {
 		double min = 2.0;
 		Arbitrary<Double> doubleArbitrary = Arbitraries.doubles().greaterOrEqual(min).ofScale(0);
 		RandomGenerator<Double> generator = doubleArbitrary.generator(100);
@@ -113,7 +113,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesWithSpecials(@ForAll Random random) {
+	void doublesWithSpecials(@ForAll JqwikRandom random) {
 		Arbitrary<Double> arbitrary = Arbitraries.doubles().between(1.0, 10.0)
 												 .withSpecialValue(Double.NaN)
 												 .withSpecialValue(Double.MIN_VALUE);
@@ -134,7 +134,7 @@ class DoubleArbitraryTests {
 	}
 
 	@Example
-	void doublesWithStandardSpecials(@ForAll Random random) {
+	void doublesWithStandardSpecials(@ForAll JqwikRandom random) {
 		Arbitrary<Double> arbitrary = Arbitraries.doubles().between(1.0, 10.0)
 												 .withStandardSpecialValues();
 		RandomGenerator<Double> generator = arbitrary.generator(100);

--- a/engine/src/test/java/net/jqwik/api/FlatCombinatorsTests.java
+++ b/engine/src/test/java/net/jqwik/api/FlatCombinatorsTests.java
@@ -11,7 +11,7 @@ import static net.jqwik.testing.TestingSupport.*;
 
 class FlatCombinatorsTests {
 
-	private final Random random = SourceOfRandomness.current();
+	private final JqwikRandom random = SourceOfRandomness.current();
 
 	@Example
 	void twoArbitrariesCanBeCombined() {
@@ -22,7 +22,7 @@ class FlatCombinatorsTests {
 	}
 
 	@Example
-	void filteringWorksWithFlatAs(@ForAll Random random) {
+	void filteringWorksWithFlatAs(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> upToThree = Arbitraries.integers().between(0, 3);
 		Arbitrary<Integer> combine2 = Combinators.combine(upToThree, upToThree)
 												 .filter((a, b) -> a + b == 3)
@@ -85,7 +85,7 @@ class FlatCombinatorsTests {
 	}
 
 	@Example
-	void listOfArbitrariesCanBeCombined(@ForAll Random random) {
+	void listOfArbitrariesCanBeCombined(@ForAll JqwikRandom random) {
 		List<Arbitrary<Integer>> listOfArbitraries = Arrays.asList(one(), two(), three());
 		Arbitrary<Integer> combineList =
 			Combinators.combine(listOfArbitraries)

--- a/engine/src/test/java/net/jqwik/api/FloatArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/FloatArbitraryTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class FloatArbitraryTests {
 
 	@Example
-	void floatMinsAndMaxesWithEdgeCases(@ForAll Random random) {
+	void floatMinsAndMaxesWithEdgeCases(@ForAll JqwikRandom random) {
 		RandomGenerator<Float> generator = Arbitraries.floats().generator(1, true);
 		assertAtLeastOneGeneratedOf(
 			generator, random,
@@ -23,7 +23,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floats(@ForAll Random random) {
+	void floats(@ForAll JqwikRandom random) {
 		Arbitrary<Float> floatArbitrary = Arbitraries.floats().between(-10.0f, 10.0f).ofScale(2);
 		RandomGenerator<Float> generator = floatArbitrary.generator(1, true);
 
@@ -37,7 +37,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floatsWithBordersExcluded(@ForAll Random random) {
+	void floatsWithBordersExcluded(@ForAll JqwikRandom random) {
 		float min = 1.0f;
 		float max = 2.0f;
 		Arbitrary<Float> floatArbitrary = Arbitraries.floats().between(min, false, max, false).ofScale(1);
@@ -46,7 +46,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floatsLessThan(@ForAll Random random) {
+	void floatsLessThan(@ForAll JqwikRandom random) {
 		float max = 2.0f;
 		Arbitrary<Float> floatArbitrary = Arbitraries.floats().lessThan(max).ofScale(0);
 		RandomGenerator<Float> generator = floatArbitrary.generator(100);
@@ -54,7 +54,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floatsLessOrEqual(@ForAll Random random) {
+	void floatsLessOrEqual(@ForAll JqwikRandom random) {
 		float max = 2.0f;
 		Arbitrary<Float> floatArbitrary = Arbitraries.floats().lessOrEqual(max).ofScale(0);
 		RandomGenerator<Float> generator = floatArbitrary.generator(100);
@@ -62,7 +62,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floatsGreaterThan(@ForAll Random random) {
+	void floatsGreaterThan(@ForAll JqwikRandom random) {
 		float min = 2.0f;
 		Arbitrary<Float> floatArbitrary = Arbitraries.floats().greaterThan(min).ofScale(0);
 		RandomGenerator<Float> generator = floatArbitrary.generator(100);
@@ -70,7 +70,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floatsGreaterOrEqual(@ForAll Random random) {
+	void floatsGreaterOrEqual(@ForAll JqwikRandom random) {
 		float min = 2.0f;
 		Arbitrary<Float> floatArbitrary = Arbitraries.floats().greaterOrEqual(min).ofScale(0);
 		RandomGenerator<Float> generator = floatArbitrary.generator(100);
@@ -86,7 +86,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floatsWithSpecials(@ForAll Random random) {
+	void floatsWithSpecials(@ForAll JqwikRandom random) {
 		Arbitrary<Float> arbitrary = Arbitraries.floats().between(1.0f, 10.0f)
 												.withSpecialValue(Float.NaN)
 												.withSpecialValue(Float.MIN_VALUE);
@@ -107,7 +107,7 @@ class FloatArbitraryTests {
 	}
 
 	@Example
-	void floatsWithStandardSpecials(@ForAll Random random) {
+	void floatsWithStandardSpecials(@ForAll JqwikRandom random) {
 		Arbitrary<Float> arbitrary = Arbitraries.floats().between(1.0f, 10.0f)
 												.withStandardSpecialValues();
 		RandomGenerator<Float> generator = arbitrary.generator(100);

--- a/engine/src/test/java/net/jqwik/api/FunctionsTests.java
+++ b/engine/src/test/java/net/jqwik/api/FunctionsTests.java
@@ -35,7 +35,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void function_creates_same_result_for_same_input(@ForAll Random random) {
+	void function_creates_same_result_for_same_input(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.integers().between(1, 10);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -48,7 +48,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void some_functions_create_different_result_for_different_input(@ForAll Random random) {
+	void some_functions_create_different_result_for_different_input(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.integers().between(1, 10);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -61,7 +61,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void toString_of_functions_can_be_called(@ForAll Random random) {
+	void toString_of_functions_can_be_called(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.just(42);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -72,7 +72,7 @@ class FunctionsTests {
 
 	@Example
 	@StatisticsReport(onFailureOnly = true)
-	void hashCode_of_functions_can_be_called(@ForAll Random random) {
+	void hashCode_of_functions_can_be_called(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.integers().between(1, 10000);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -94,7 +94,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void equals_of_functions_can_be_called(@ForAll Random random) {
+	void equals_of_functions_can_be_called(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.integers().between(1, 10000);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -107,7 +107,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void default_methods_of_functions_can_be_called(@ForAll Random random) {
+	void default_methods_of_functions_can_be_called(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.just(42);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -120,7 +120,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void default_methods_of_self_made_functional_interface_can_be_called(@ForAll Random random) {
+	void default_methods_of_self_made_functional_interface_can_be_called(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.just(42);
 		Arbitrary<MyFunctionalInterface<String, String, Integer>> functions =
 			Functions.function(MyFunctionalInterface.class).returning(integers);
@@ -130,7 +130,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void null_value_is_accepted_as_input(@ForAll Random random) {
+	void null_value_is_accepted_as_input(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.integers().between(1, 10);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -143,7 +143,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void supplier_always_returns_same_element(@ForAll Random random) {
+	void supplier_always_returns_same_element(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.integers().between(1, 10);
 		Arbitrary<Supplier<Integer>> functions =
 			Functions.function(Supplier.class).returning(integers);
@@ -156,7 +156,7 @@ class FunctionsTests {
 	}
 
 	@Example
-	void consumer_accepts_anything(@ForAll Random random) {
+	void consumer_accepts_anything(@ForAll JqwikRandom random) {
 		Arbitrary<Consumer<Integer>> functions =
 			Functions.function(Consumer.class).returning(Arbitraries.nothing());
 
@@ -193,7 +193,7 @@ class FunctionsTests {
 	}
 
 	@Property(tries = 100, afterFailure = AfterFailureMode.RANDOM_SEED)
-	void functions_are_shrunk_to_constant_functions(@ForAll Random random) {
+	void functions_are_shrunk_to_constant_functions(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integers = Arbitraries.integers().between(1, 20);
 		Arbitrary<Function<String, Integer>> functions =
 			Functions.function(Function.class).returning(integers);
@@ -282,7 +282,7 @@ class FunctionsTests {
 	@Group
 	class Conditional_results {
 		@Example
-		void function_with_conditional_answer(@ForAll Random random) {
+		void function_with_conditional_answer(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integers = Arbitraries.integers().between(1, 100);
 			Arbitrary<Function<String, Integer>> functions =
 				Functions
@@ -298,7 +298,7 @@ class FunctionsTests {
 		}
 
 		@Example
-		void first_matching_conditional_answer_is_used(@ForAll Random random) {
+		void first_matching_conditional_answer_is_used(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integers = Arbitraries.integers().between(1, 100);
 			Arbitrary<Function<String, Integer>> functions =
 				Functions
@@ -314,7 +314,7 @@ class FunctionsTests {
 		}
 
 		@Example
-		void function_with_conditional_null_answer(@ForAll Random random) {
+		void function_with_conditional_null_answer(@ForAll JqwikRandom random) {
 			Arbitrary<String> integers = Arbitraries.of("1", "2", "3");
 			Arbitrary<Function<String, String>> functions =
 				Functions
@@ -349,7 +349,7 @@ class FunctionsTests {
 		}
 
 		@Example
-		void conditional_answer_works_when_shrunk(@ForAll Random random) {
+		void conditional_answer_works_when_shrunk(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integers = Arbitraries.integers().between(1, 100);
 			Arbitrary<Function<String, Integer>> functions =
 				Functions

--- a/engine/src/test/java/net/jqwik/api/GenericGenerationProperties.java
+++ b/engine/src/test/java/net/jqwik/api/GenericGenerationProperties.java
@@ -24,7 +24,7 @@ public interface GenericGenerationProperties {
 	@Property(tries = 100)
 	default void sameRandomWillGenerateSameValueOnFreshGenerator(
 		@ForAll("arbitraries") Arbitrary<?> arbitrary,
-		@ForAll Random random,
+		@ForAll JqwikRandom random,
 		@ForAll @IntRange(min = 1, max = 10000) int genSize,
 		@ForAll boolean withEdgeCases
 	) {
@@ -42,7 +42,7 @@ public interface GenericGenerationProperties {
 
 	@Property(tries = 100)
 	default void memoizableArbitrariesWillMemoizeGenerators(
-		@ForAll Random randomToGenerateArbitrary,
+		@ForAll JqwikRandom randomToGenerateArbitrary,
 		@ForAll @IntRange(min = 1, max = 10000) int genSize,
 		@ForAll boolean withEdgeCases
 	) {
@@ -69,8 +69,8 @@ public interface GenericGenerationProperties {
 
 	@Property(tries = 100)
 	default void sameRandomWillGenerateSameValueOnMemoizedGenerator(
-		@ForAll Random randomToGenerateArbitrary,
-		@ForAll Random randomToGenerateValue,
+		@ForAll JqwikRandom randomToGenerateArbitrary,
+		@ForAll JqwikRandom randomToGenerateValue,
 		@ForAll @IntRange(min = 1, max = 10000) int genSize,
 		@ForAll boolean withEdgeCases
 	) {

--- a/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/IteratorArbitraryTests.java
@@ -17,7 +17,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class IteratorArbitraryTests {
 
 	@Example
-	void iterators(@ForAll Random random) {
+	void iterators(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		IteratorArbitrary<Integer> streamArbitrary = integerArbitrary.iterator().ofMinSize(0).ofMaxSize(5);
 
@@ -31,7 +31,7 @@ class IteratorArbitraryTests {
 
 	@Example
 	@StatisticsReport(onFailureOnly = true)
-	void withSizeDistribution(@ForAll Random random) {
+	void withSizeDistribution(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 		IteratorArbitrary<Integer> arbitrary =
 			integerArbitrary.iterator().ofMaxSize(100)
@@ -53,7 +53,7 @@ class IteratorArbitraryTests {
 	}
 
 	@Example
-	void uniquenessConstraint(@ForAll Random random) {
+	void uniquenessConstraint(@ForAll JqwikRandom random) {
 		IteratorArbitrary<Integer> listArbitrary =
 				Arbitraries.integers().between(1, 1000).iterator().ofMaxSize(20)
 						   .uniqueElements(i -> i % 100);
@@ -66,7 +66,7 @@ class IteratorArbitraryTests {
 	}
 
 	@Example
-	void uniquenessElements(@ForAll Random random) {
+	void uniquenessElements(@ForAll JqwikRandom random) {
 		IteratorArbitrary<Integer> listArbitrary =
 				Arbitraries.integers().between(1, 1000).iterator().ofMaxSize(20).uniqueElements();
 
@@ -193,14 +193,14 @@ class IteratorArbitraryTests {
 	class Shrinking {
 
 		@Property
-		void shrinksToEmptyStreamByDefault(@ForAll Random random) {
+		void shrinksToEmptyStreamByDefault(@ForAll JqwikRandom random) {
 			IteratorArbitrary<Integer> iterators = Arbitraries.integers().between(1, 10).iterator();
 			Iterator<Integer> value = falsifyThenShrink(iterators, random);
 			assertThat(value.hasNext()).isFalse();
 		}
 
 		@Property
-		void shrinkToMinSize(@ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int min) {
+		void shrinkToMinSize(@ForAll JqwikRandom random, @ForAll @IntRange(min = 1, max = 20) int min) {
 			IteratorArbitrary<Integer> iterators = Arbitraries.integers().between(1, 10).iterator().ofMinSize(min);
 			Iterator<Integer> value = falsifyThenShrink(iterators, random);
 			List<Integer> list = toList(value);

--- a/engine/src/test/java/net/jqwik/api/ListArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/ListArbitraryTests.java
@@ -63,7 +63,7 @@ class ListArbitraryTests {
 
 	// Lists of that size often lead to OutOfMemoryError
 	// @Property(tries = 10)
-	void ofMinSize_closeToIntegerMax(@ForAll @IntRange(min = Integer.MAX_VALUE / 2) int minSize, @ForAll Random random) {
+	void ofMinSize_closeToIntegerMax(@ForAll @IntRange(min = Integer.MAX_VALUE / 2) int minSize, @ForAll JqwikRandom random) {
 		ListArbitrary<Integer> listArbitrary = Arbitraries.of(1,2,3).list().ofMinSize(minSize);
 		RandomGenerator<List<Integer>> generator = listArbitrary.generator(1, true);
 
@@ -72,7 +72,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void reduceList(@ForAll Random random) {
+	void reduceList(@ForAll JqwikRandom random) {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 5).list().ofMinSize(1).ofMaxSize(10);
 
@@ -89,7 +89,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void uniqueElements(@ForAll Random random) {
+	void uniqueElements(@ForAll JqwikRandom random) {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 1000).list().ofMaxSize(20)
 					   .uniqueElements(i -> i % 100);
@@ -102,7 +102,7 @@ class ListArbitraryTests {
 	}
 
 	@Property(tries = 10)
-	void uniqueElementsWithoutMaxSize(@ForAll Random random, @ForAll @IntRange(max = 10) int minSize) {
+	void uniqueElementsWithoutMaxSize(@ForAll JqwikRandom random, @ForAll @IntRange(max = 10) int minSize) {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 1000).list().ofMinSize(minSize)
 					   .uniqueElements(i -> i % 10);
@@ -115,7 +115,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void uniqueElementsWithNull(@ForAll Random random) {
+	void uniqueElementsWithNull(@ForAll JqwikRandom random) {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 1000).injectNull(0.5)
 					   .list().ofMaxSize(20)
@@ -129,7 +129,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void multipleUniquenessConstraints(@ForAll Random random) {
+	void multipleUniquenessConstraints(@ForAll JqwikRandom random) {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 1000).list().ofMaxSize(20)
 					   .uniqueElements(i -> i % 99)
@@ -144,7 +144,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void uniquenessConstraintCannotBeFulfilled(@ForAll Random random) {
+	void uniquenessConstraintCannotBeFulfilled(@ForAll JqwikRandom random) {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 1000).list().ofSize(10)
 					   .uniqueElements(i -> i % 5);
@@ -155,7 +155,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void uniquenessElements(@ForAll Random random) {
+	void uniquenessElements(@ForAll JqwikRandom random) {
 		ListArbitrary<Integer> listArbitrary =
 			Arbitraries.integers().between(1, 1000).list().ofMaxSize(20).uniqueElements();
 
@@ -167,7 +167,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void uniqueListsAreSometimesGeneratedByDefault(@ForAll Random random) {
+	void uniqueListsAreSometimesGeneratedByDefault(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(0, 1_000);
 		ListArbitrary<Integer> listArbitrary = integerArbitrary.list().ofSize(50);
 
@@ -184,7 +184,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void uniqueListsAreSometimesGeneratedByDefaultEvenIfMaxSizeDoesNotAllowThat(@ForAll Random random) {
+	void uniqueListsAreSometimesGeneratedByDefaultEvenIfMaxSizeDoesNotAllowThat(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(0, 10);
 		ListArbitrary<Integer> listArbitrary = integerArbitrary.list().ofMaxSize(50);
 
@@ -204,7 +204,7 @@ class ListArbitraryTests {
 	class SizeDistribution {
 
 		@Example
-		void use_explicit_size_distribution(@ForAll Random random) {
+		void use_explicit_size_distribution(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 			ListArbitrary<Integer> arbitrary =
 				integerArbitrary.list().ofMaxSize(100)
@@ -225,7 +225,7 @@ class ListArbitraryTests {
 		}
 
 		@Example
-		void without_explicit_size_distribution_each_possible_size_should_be_generated(@ForAll Random random) {
+		void without_explicit_size_distribution_each_possible_size_should_be_generated(@ForAll JqwikRandom random) {
 			int maxSize = 50;
 			Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 			ListArbitrary<Integer> listArbitrary = integerArbitrary.list().ofMaxSize(maxSize);
@@ -245,7 +245,7 @@ class ListArbitraryTests {
 		}
 
 		@Example
-		void without_explicit_size_distribution_max_size_should_be_generated_regularly(@ForAll Random random) {
+		void without_explicit_size_distribution_max_size_should_be_generated_regularly(@ForAll JqwikRandom random) {
 			int maxSize = 1000;
 			Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 			ListArbitrary<Integer> listArbitrary = integerArbitrary.list().ofMaxSize(maxSize);
@@ -277,7 +277,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void mapEach(@ForAll Random random) {
+	void mapEach(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		Arbitrary<List<Tuple.Tuple2<Integer, List<Integer>>>> setArbitrary =
 			integerArbitrary
@@ -315,13 +315,13 @@ class ListArbitraryTests {
 		}
 
 		@Example
-		void plain(@ForAll Random random) {
+		void plain(@ForAll JqwikRandom random) {
 			Arbitrary<List<Integer>> listOfBytes = Arbitraries.integers().list().ofSize(largeSize);
 			checkAllGenerated(listOfBytes.generator(1000), random, bytes -> bytes.size() == largeSize);
 		}
 
 		@Example
-		void unique(@ForAll Random random) {
+		void unique(@ForAll JqwikRandom random) {
 			Arbitrary<List<Integer>> uniqueIntegers = Arbitraries.integers().list().ofSize(largeSize).uniqueElements();
 			RandomGenerator<List<Integer>> generator = uniqueIntegers.generator(1000);
 			List<Integer> list = generator.next(random).value();
@@ -330,7 +330,7 @@ class ListArbitraryTests {
 		}
 
 		@Example
-		void uniqueBy(@ForAll Random random) {
+		void uniqueBy(@ForAll JqwikRandom random) {
 			Function<IntegerAbs,Object> keyExtractor = x -> x.value;
 			Arbitrary<List<IntegerAbs>> uniqueBytes = Arbitraries.integers().map(IntegerAbs::new).list().ofSize(largeSize).uniqueElements(keyExtractor);
 			RandomGenerator<List<IntegerAbs>> generator = uniqueBytes.generator(1000);
@@ -348,7 +348,7 @@ class ListArbitraryTests {
 	}
 
 	@Example
-	void flatMapEach(@ForAll Random random) {
+	void flatMapEach(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		Arbitrary<List<Tuple.Tuple2<Integer, Integer>>> setArbitrary =
 			integerArbitrary
@@ -532,14 +532,14 @@ class ListArbitraryTests {
 	class Shrinking {
 
 		@Property
-		void shrinksToEmptyListByDefault(@ForAll Random random) {
+		void shrinksToEmptyListByDefault(@ForAll JqwikRandom random) {
 			ListArbitrary<Integer> lists = Arbitraries.integers().between(1, 10).list();
 			List<Integer> value = falsifyThenShrink(lists, random);
 			assertThat(value).isEmpty();
 		}
 
 		@Property
-		void shrinkToMinSize(@ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int min) {
+		void shrinkToMinSize(@ForAll JqwikRandom random, @ForAll @IntRange(min = 1, max = 20) int min) {
 			ListArbitrary<Integer> lists = Arbitraries.integers().between(1, 10).list().ofMinSize(min);
 			List<Integer> value = falsifyThenShrink(lists, random);
 			assertThat(value).hasSize(min);
@@ -547,7 +547,7 @@ class ListArbitraryTests {
 		}
 
 		@Property
-		void shrinkWithUniqueness(@ForAll Random random, @ForAll @IntRange(min = 2, max = 10) int min) {
+		void shrinkWithUniqueness(@ForAll JqwikRandom random, @ForAll @IntRange(min = 2, max = 10) int min) {
 			ListArbitrary<Integer> lists =
 				Arbitraries.integers().between(1, 100).list().ofMinSize(min).ofMaxSize(10)
 						   .uniqueElements(i -> i);
@@ -560,7 +560,7 @@ class ListArbitraryTests {
 		}
 
 		@Property
-		void shrinkWithUniquenessAndNulls(@ForAll Random random) {
+		void shrinkWithUniquenessAndNulls(@ForAll JqwikRandom random) {
 			ListArbitrary<Integer> lists =
 				Arbitraries.integers().between(1, 100).injectNull(0.5)
 						   .list().ofMinSize(3).ofMaxSize(10)
@@ -599,7 +599,7 @@ class ListArbitraryTests {
 	}
 
 	private void assertGeneratedLists(RandomGenerator<List<String>> generator, int minSize, int maxSize) {
-		Random random = SourceOfRandomness.current();
+		JqwikRandom random = SourceOfRandomness.current();
 		assertAllGenerated(generator, random, list -> {
 			assertThat(list.size()).isBetween(minSize, maxSize);
 			assertThat(list).isSubsetOf("1", "hallo", "test");

--- a/engine/src/test/java/net/jqwik/api/MapArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/MapArbitraryTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class MapArbitraryTests {
 
 	@Example
-	void map(@ForAll Random random) {
+	void map(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> keys = Arbitraries.integers().between(1, 10);
 		Arbitrary<String> values = Arbitraries.strings().alpha().ofLength(5);
 
@@ -51,7 +51,7 @@ class MapArbitraryTests {
 	}
 
 	@Example
-	void mapWithLessElementsThanMaxSize(@ForAll Random random) {
+	void mapWithLessElementsThanMaxSize(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> keys = Arbitraries.integers().between(1, 3);
 		Arbitrary<String> values = Arbitraries.strings().alpha().ofLength(5);
 
@@ -70,7 +70,7 @@ class MapArbitraryTests {
 
 	@Example
 	@StatisticsReport(StatisticsReport.StatisticsReportMode.OFF)
-	void withSizeDistribution(@ForAll Random random) {
+	void withSizeDistribution(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> keys = Arbitraries.integers();
 		Arbitrary<String> values = Arbitraries.strings().alpha().ofLength(5);
 
@@ -93,7 +93,7 @@ class MapArbitraryTests {
 	}
 
 	@Example
-	void keyUniqueness(@ForAll Random random) {
+	void keyUniqueness(@ForAll JqwikRandom random) {
 		MapArbitrary<Integer, String> mapArbitrary =
 			Arbitraries.maps(
 				Arbitraries.integers().between(1, 1000),
@@ -108,7 +108,7 @@ class MapArbitraryTests {
 	}
 
 	@Example
-	void valueUniqueness(@ForAll Random random) {
+	void valueUniqueness(@ForAll JqwikRandom random) {
 		MapArbitrary<String, Integer> mapArbitrary =
 			Arbitraries.maps(
 				Arbitraries.strings().alpha().ofMaxLength(10),
@@ -123,7 +123,7 @@ class MapArbitraryTests {
 	}
 
 	@Example
-	void uniqueValues(@ForAll Random random) {
+	void uniqueValues(@ForAll JqwikRandom random) {
 		MapArbitrary<String, Integer> mapArbitrary =
 			Arbitraries.maps(
 				Arbitraries.strings().alpha().ofMaxLength(10),
@@ -302,7 +302,7 @@ class MapArbitraryTests {
 	class Shrinking {
 
 		@Property(tries = 10)
-		void mapIsShrunkToEmptyMap(@ForAll Random random) {
+		void mapIsShrunkToEmptyMap(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> keys = Arbitraries.integers().between(-10, 10);
 			Arbitrary<String> values = Arbitraries.strings().alpha().ofLength(1);
 
@@ -313,7 +313,7 @@ class MapArbitraryTests {
 		}
 
 		@Property(tries = 10)
-		void mapIsShrunkToSmallestValue(@ForAll Random random) {
+		void mapIsShrunkToSmallestValue(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> keys = Arbitraries.integers().between(-10, 10);
 			Arbitrary<String> values = Arbitraries.strings().withCharRange('A', 'Z').ofLength(1);
 

--- a/engine/src/test/java/net/jqwik/api/SetArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/SetArbitraryTests.java
@@ -18,7 +18,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class SetArbitraryTests {
 
 	@Example
-	void set(@ForAll Random random) {
+	void set(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		SetArbitrary<Integer> setArbitrary = integerArbitrary.set().ofMinSize(2).ofMaxSize(7);
 
@@ -28,7 +28,7 @@ class SetArbitraryTests {
 	}
 
 	@Example
-	void largeSetOfFixedSize(@ForAll Random random) {
+	void largeSetOfFixedSize(@ForAll JqwikRandom random) {
 		int size = 1000;
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 		SetArbitrary<Integer> setArbitrary = integerArbitrary.set().ofSize(size);
@@ -42,7 +42,7 @@ class SetArbitraryTests {
 	}
 
 	@Example
-	void setWithLessElementsThanMaxSize(@ForAll Random random) {
+	void setWithLessElementsThanMaxSize(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.of(1, 2, 3, 4, 5);
 		SetArbitrary<Integer> setArbitrary = integerArbitrary.set().ofMinSize(2);
 
@@ -52,7 +52,7 @@ class SetArbitraryTests {
 	}
 
 	@Example
-	void mapEach(@ForAll Random random) {
+	void mapEach(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		Arbitrary<Set<Tuple.Tuple2<Integer, Set<Integer>>>> setArbitrary =
 			integerArbitrary
@@ -72,7 +72,7 @@ class SetArbitraryTests {
 	}
 
 	@Example
-	void flatMapEach(@ForAll Random random) {
+	void flatMapEach(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		Arbitrary<Set<Tuple.Tuple2<Integer, Integer>>> setArbitrary =
 			integerArbitrary
@@ -94,7 +94,7 @@ class SetArbitraryTests {
 	}
 
 	@Example
-	void multipleUniquenessConstraints(@ForAll Random random) {
+	void multipleUniquenessConstraints(@ForAll JqwikRandom random) {
 		SetArbitrary<Integer> setArbitrary =
 			Arbitraries.integers().between(1, 1000).set().ofMaxSize(20)
 					   .uniqueElements(i -> i % 99)
@@ -110,7 +110,7 @@ class SetArbitraryTests {
 
 	@Example
 	@StatisticsReport(onFailureOnly = true)
-	void withSizeDistribution(@ForAll Random random) {
+	void withSizeDistribution(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 		SetArbitrary<Integer> arbitrary =
 			integerArbitrary.set().ofMaxSize(100)
@@ -290,14 +290,14 @@ class SetArbitraryTests {
 	class Shrinking {
 
 		@Property
-		void shrinksToEmptySetByDefault(@ForAll Random random) {
+		void shrinksToEmptySetByDefault(@ForAll JqwikRandom random) {
 			SetArbitrary<Integer> sets = Arbitraries.integers().between(1, 10).set();
 			Set<Integer> value = falsifyThenShrink(sets, random);
 			assertThat(value).isEmpty();
 		}
 
 		@Property
-		void shrinkToMinSize(@ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int min) {
+		void shrinkToMinSize(@ForAll JqwikRandom random, @ForAll @IntRange(min = 1, max = 20) int min) {
 			SetArbitrary<Integer> sets = Arbitraries.integers().between(1, 100).set().ofMinSize(min);
 			Set<Integer> value = falsifyThenShrink(sets, random);
 			assertThat(value).hasSize(min);
@@ -306,7 +306,7 @@ class SetArbitraryTests {
 		}
 
 		@Property
-		void shrinkWithUniqueness(@ForAll Random random, @ForAll @IntRange(min = 2, max = 9) int min) {
+		void shrinkWithUniqueness(@ForAll JqwikRandom random, @ForAll @IntRange(min = 2, max = 9) int min) {
 			SetArbitrary<Integer> lists =
 				Arbitraries.integers().between(1, 1000).set().ofMinSize(min).ofMaxSize(9)
 						   .uniqueElements(i -> i % 10);
@@ -320,7 +320,7 @@ class SetArbitraryTests {
 
 	}
 
-	private void assertGeneratedSet(RandomGenerator<Set<Integer>> generator, Random random, int minSize, int maxSize) {
+	private void assertGeneratedSet(RandomGenerator<Set<Integer>> generator, JqwikRandom random, int minSize, int maxSize) {
 		assertAllGenerated(generator, random, set -> {
 			assertThat(set.size()).isBetween(minSize, maxSize);
 			assertThat(set).isSubsetOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);

--- a/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/api/StreamArbitraryTests.java
@@ -21,7 +21,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class StreamArbitraryTests {
 
 	@Example
-	void stream(@ForAll Random random) {
+	void stream(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 10);
 		StreamArbitrary<Integer> streamArbitrary = integerArbitrary.stream().ofMinSize(0).ofMaxSize(5);
 
@@ -34,7 +34,7 @@ class StreamArbitraryTests {
 	}
 
 	@Property(tries = 100)
-	void filterStream(@ForAll Random random) {
+	void filterStream(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers().between(1, 11);
 		Arbitrary<Stream<Integer>> streamArbitrary = integerArbitrary.stream().ofMinSize(0).ofMaxSize(5)
 				.filter(stream -> !stream.collect(Collectors.toList()).contains(11));
@@ -48,7 +48,7 @@ class StreamArbitraryTests {
 	}
 
 	@Example
-	void uniquenessConstraint(@ForAll Random random) {
+	void uniquenessConstraint(@ForAll JqwikRandom random) {
 		StreamArbitrary<Integer> listArbitrary =
 				Arbitraries.integers().between(1, 1000).stream().ofMaxSize(20)
 						   .uniqueElements(i -> i % 100);
@@ -61,7 +61,7 @@ class StreamArbitraryTests {
 	}
 
 	@Example
-	void uniquenessElements(@ForAll Random random) {
+	void uniquenessElements(@ForAll JqwikRandom random) {
 		StreamArbitrary<Integer> listArbitrary =
 				Arbitraries.integers().between(1, 1000).stream().ofMaxSize(20).uniqueElements();
 
@@ -74,7 +74,7 @@ class StreamArbitraryTests {
 
 	@Example
 	@StatisticsReport(onFailureOnly = true)
-	void withSizeDistribution(@ForAll Random random) {
+	void withSizeDistribution(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integerArbitrary = Arbitraries.integers();
 		StreamArbitrary<Integer> arbitrary =
 			integerArbitrary.stream().ofMaxSize(100)
@@ -225,14 +225,14 @@ class StreamArbitraryTests {
 	class Shrinking {
 
 		@Property
-		void shrinksToEmptyStreamByDefault(@ForAll Random random) {
+		void shrinksToEmptyStreamByDefault(@ForAll JqwikRandom random) {
 			StreamArbitrary<Integer> streams = Arbitraries.integers().between(1, 10).stream();
 			Stream<Integer> value = falsifyThenShrink(streams, random);
 			assertThat(value).isEmpty();
 		}
 
 		@Property
-		void shrinkToMinSize(@ForAll Random random, @ForAll @IntRange(min = 1, max = 20) int min) {
+		void shrinkToMinSize(@ForAll JqwikRandom random, @ForAll @IntRange(min = 1, max = 20) int min) {
 			StreamArbitrary<Integer> streams = Arbitraries.integers().between(1, 10).stream().ofMinSize(min);
 			Stream<Integer> value = falsifyThenShrink(streams, random);
 			List<Integer> list = toList(value);
@@ -241,7 +241,7 @@ class StreamArbitraryTests {
 		}
 
 		@Property
-		void shrinkWithUniqueness(@ForAll Random random, @ForAll @IntRange(min = 2, max = 10) int min) {
+		void shrinkWithUniqueness(@ForAll JqwikRandom random, @ForAll @IntRange(min = 2, max = 10) int min) {
 			StreamArbitrary<Integer> lists =
 					Arbitraries.integers().between(1, 100).stream().ofMinSize(min).ofMaxSize(10)
 							   .uniqueElements(i -> i);

--- a/engine/src/test/java/net/jqwik/api/constraints/UseTypeProperties.java
+++ b/engine/src/test/java/net/jqwik/api/constraints/UseTypeProperties.java
@@ -61,7 +61,7 @@ class UseTypeProperties {
 	@Domain(SmallNumbers.class)
 	void useTypeShouldWorkRegardlessOfDomainContext(
 		@ForAll int smallNumber,
-		@ForAll @UseType Random random
+		@ForAll JqwikRandom random
 	) {
 		assertThat(smallNumber).isBetween(1, 99);
 		assertThat(random).isNotNull();

--- a/engine/src/test/java/net/jqwik/api/edgeCases/ArbitraryEdgeCasesTests.java
+++ b/engine/src/test/java/net/jqwik/api/edgeCases/ArbitraryEdgeCasesTests.java
@@ -135,7 +135,7 @@ class ArbitraryEdgeCasesTests implements GenericEdgeCasesProperties {
 	class GenericConfiguration {
 
 		@Example
-		void noEdgeCases(@ForAll Random random) {
+		void noEdgeCases(@ForAll JqwikRandom random) {
 			Arbitrary<String> arbitrary =
 				Arbitraries
 					.of("one", "two", "three")

--- a/engine/src/test/java/net/jqwik/engine/execution/reporting/SampleReportingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/execution/reporting/SampleReportingTests.java
@@ -594,7 +594,7 @@ class SampleReportingTests {
 		class Streams {
 
 			@Example
-			void generatedStreamsCanBeReportedBeforeEvaluation(@ForAll Random random) {
+			void generatedStreamsCanBeReportedBeforeEvaluation(@ForAll JqwikRandom random) {
 				Arbitrary<Stream<Integer>> streams = Arbitraries.just(1).stream().ofSize(3);
 				Stream<Integer> stream = streams.generator(10, true).next(random).value();
 
@@ -603,7 +603,7 @@ class SampleReportingTests {
 			}
 
 			@Example
-			void generatedStreamsCanBeReportedWithoutEvaluation(@ForAll Random random) {
+			void generatedStreamsCanBeReportedWithoutEvaluation(@ForAll JqwikRandom random) {
 				Arbitrary<Stream<Integer>> streams = Arbitraries.just(1).stream().ofSize(3);
 				Stream<Integer> stream = streams.generator(10, true).next(random).value();
 

--- a/engine/src/test/java/net/jqwik/engine/properties/GenericPropertyTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/GenericPropertyTests.java
@@ -501,7 +501,7 @@ class GenericPropertyTests {
 	}
 
 	private ParametersGenerator randomizedShrinkablesGenerator(Arbitrary<Object>... arbitraries) {
-		Random random = SourceOfRandomness.current();
+		JqwikRandom random = SourceOfRandomness.current();
 		List<Arbitrary<Object>> arbitraryList = Arrays.stream(arbitraries).collect(Collectors.toList());
 		List<RandomGenerator<Object>> generators = arbitraryList
 			.stream()

--- a/engine/src/test/java/net/jqwik/engine/properties/PropertyMethodArbitraryResolverTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/PropertyMethodArbitraryResolverTests.java
@@ -210,7 +210,7 @@ class PropertyMethodArbitraryResolverTests {
 
 		@SuppressWarnings("unchecked")
 		@Example
-		void providerMethodCanHaveForAllParameters(@ForAll Random random) {
+		void providerMethodCanHaveForAllParameters(@ForAll JqwikRandom random) {
 			PropertyMethodArbitraryResolver provider = getResolver(WithNamedProviders.class);
 			MethodParameter parameter = getParameter(WithNamedProviders.class, "tuple2WithThingAndString");
 			Set<Arbitrary<?>> arbitraries = provider.forParameter(parameter);
@@ -264,7 +264,7 @@ class PropertyMethodArbitraryResolverTests {
 		}
 
 		@Example
-		void findGeneratorByNameInFromAnnotationOfTypeParameter(@ForAll Random random) {
+		void findGeneratorByNameInFromAnnotationOfTypeParameter(@ForAll JqwikRandom random) {
 			PropertyMethodArbitraryResolver provider = getResolver(WithNamedProviders.class);
 			MethodParameter parameter = getParameter(WithNamedProviders.class, "listOfThingFrom");
 			Set<Arbitrary<?>> arbitraries = provider.forParameter(parameter);
@@ -312,7 +312,7 @@ class PropertyMethodArbitraryResolverTests {
 		}
 
 		@Example
-		void findGeneratorByNameOutsideGroup(@ForAll Random random) {
+		void findGeneratorByNameOutsideGroup(@ForAll JqwikRandom random) {
 			PropertyMethodArbitraryResolver provider = getResolver(WithNamedProviders.NestedWithNamedProviders.class);
 			MethodParameter parameter = getParameter(WithNamedProviders.NestedWithNamedProviders.class, "nestedThing");
 			Set<Arbitrary<?>> arbitraries = provider.forParameter(parameter);
@@ -350,7 +350,7 @@ class PropertyMethodArbitraryResolverTests {
 		}
 
 		@Example
-		void provideAnnotationCanHaveIgnoreExceptionsAttribute(@ForAll Random random) {
+		void provideAnnotationCanHaveIgnoreExceptionsAttribute(@ForAll JqwikRandom random) {
 			PropertyMethodArbitraryResolver provider = getResolver(WithNamedProviders.class);
 			MethodParameter parameter = getParameter(WithNamedProviders.class, "integersFromProvideMethodWithIgnoreExceptions");
 			Set<Arbitrary<?>> arbitraries = provider.forParameter(parameter);

--- a/engine/src/test/java/net/jqwik/engine/properties/RandomizedShrinkablesGeneratorTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/RandomizedShrinkablesGeneratorTests.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.*;
 class RandomizedShrinkablesGeneratorTests {
 
 	@Example
-	void useSimpleRegisteredArbitraryProviders(@ForAll Random random) {
+	void useSimpleRegisteredArbitraryProviders(@ForAll JqwikRandom random) {
 		RandomizedShrinkablesGenerator shrinkablesGenerator = createGenerator(random, "simpleParameters");
 		List<Shrinkable<Object>> shrinkables = shrinkablesGenerator.next();
 
@@ -25,7 +25,7 @@ class RandomizedShrinkablesGeneratorTests {
 	}
 
 	@Example
-	void resetting(@ForAll Random random) {
+	void resetting(@ForAll JqwikRandom random) {
 		RandomizedShrinkablesGenerator shrinkablesGenerator = createGenerator(random, "simpleParameters");
 
 		List<Object> values1 = values(shrinkablesGenerator.next());
@@ -39,7 +39,7 @@ class RandomizedShrinkablesGeneratorTests {
 	}
 
 	@Example
-	void severalFittingArbitraries(@ForAll Random random) {
+	void severalFittingArbitraries(@ForAll JqwikRandom random) {
 
 		ArbitraryResolver arbitraryResolver = new ArbitraryResolver() {
 			@Override
@@ -69,7 +69,7 @@ class RandomizedShrinkablesGeneratorTests {
 	}
 
 	@Example
-	void sameTypeVariableGetsSameArbitrary(@ForAll Random random) {
+	void sameTypeVariableGetsSameArbitrary(@ForAll JqwikRandom random) {
 
 		ArbitraryResolver arbitraryResolver = new ArbitraryResolver() {
 			@Override
@@ -90,7 +90,7 @@ class RandomizedShrinkablesGeneratorTests {
 	}
 
 	@Example
-	void sameTypeVariableInParameterOfType(@ForAll Random random) {
+	void sameTypeVariableInParameterOfType(@ForAll JqwikRandom random) {
 
 		ArbitraryResolver arbitraryResolver = new ArbitraryResolver() {
 			@Override
@@ -140,7 +140,7 @@ class RandomizedShrinkablesGeneratorTests {
 		return shrinkables.stream().map(Shrinkable::value).collect(Collectors.toList());
 	}
 
-	private RandomizedShrinkablesGenerator createGenerator(Random random, String methodName) {
+	private RandomizedShrinkablesGenerator createGenerator(JqwikRandom random, String methodName) {
 		PropertyMethodArbitraryResolver arbitraryResolver = new PropertyMethodArbitraryResolver(
 			new MyProperties(),
 			DomainContext.global()
@@ -148,7 +148,7 @@ class RandomizedShrinkablesGeneratorTests {
 		return createGenerator(random, methodName, arbitraryResolver);
 	}
 
-	private RandomizedShrinkablesGenerator createGenerator(Random random, String methodName, ArbitraryResolver arbitraryResolver) {
+	private RandomizedShrinkablesGenerator createGenerator(JqwikRandom random, String methodName, ArbitraryResolver arbitraryResolver) {
 		PropertyMethodDescriptor methodDescriptor = createDescriptor(methodName);
 		List<MethodParameter> parameters = TestHelper.getParameters(methodDescriptor);
 

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultCharacterArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultCharacterArbitraryTests.java
@@ -25,7 +25,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	CharacterArbitrary arbitrary = new DefaultCharacterArbitrary();
 
 	@Example
-	void perDefaultNoNoncharactersAndNoPrivateUseCharactersAreCreated(@ForAll Random random) {
+	void perDefaultNoNoncharactersAndNoPrivateUseCharactersAreCreated(@ForAll JqwikRandom random) {
 		checkAllGenerated(
 			this.arbitrary.generator(1000, true),
 			random,
@@ -49,7 +49,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void edgeCasesAreGenerated(@ForAll Random random) {
+	void edgeCasesAreGenerated(@ForAll JqwikRandom random) {
 		TestingSupport.checkAtLeastOneGenerated(
 			this.arbitrary.generator(1000, true),
 			random,
@@ -58,7 +58,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void allOverridesAnythingBefore(@ForAll Random random) {
+	void allOverridesAnythingBefore(@ForAll JqwikRandom random) {
 		CharacterArbitrary all = this.arbitrary.ascii().all();
 		checkAllGenerated(
 			all.generator(1000, true),
@@ -78,7 +78,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void chars(@ForAll Random random) {
+	void chars(@ForAll JqwikRandom random) {
 		final List<Character> chars = Arrays.asList('a', 'b', 'c', '1', '2', '.');
 		CharacterArbitrary all = this.arbitrary.with('a', 'b', 'c', '1', '2', '.');
 		checkAllGenerated(
@@ -94,7 +94,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void charsFromCharSequence(@ForAll Random random) {
+	void charsFromCharSequence(@ForAll JqwikRandom random) {
 		final List<Character> chars = Arrays.asList('a', 'b', 'c', '1', '2', '.');
 		CharacterArbitrary all = this.arbitrary.with("abc12.");
 		checkAllGenerated(
@@ -110,7 +110,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void range(@ForAll Random random) {
+	void range(@ForAll JqwikRandom random) {
 		char min = '\u0010';
 		char max = '\u0030';
 		CharacterArbitrary all = this.arbitrary.range(min, max);
@@ -127,7 +127,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void digit(@ForAll Random random) {
+	void digit(@ForAll JqwikRandom random) {
 		CharacterArbitrary all = this.arbitrary.numeric();
 		checkAllGenerated(
 			all.generator(1000, true),
@@ -142,7 +142,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void ascii(@ForAll Random random) {
+	void ascii(@ForAll JqwikRandom random) {
 		CharacterArbitrary all = this.arbitrary.ascii();
 		checkAllGenerated(
 			all.generator(1000, true),
@@ -157,7 +157,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void alpha(@ForAll Random random) {
+	void alpha(@ForAll JqwikRandom random) {
 		CharacterArbitrary all = this.arbitrary.alpha();
 		checkAllGenerated(
 			all.generator(1000, true),
@@ -172,7 +172,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void addUpRangesAndChars(@ForAll Random random) {
+	void addUpRangesAndChars(@ForAll JqwikRandom random) {
 		char min1 = '\u0010';
 		char max1 = '\u0030';
 		char min2 = '\u0110';
@@ -206,7 +206,7 @@ class DefaultCharacterArbitraryTests implements GenericGenerationProperties, Gen
 	}
 
 	@Example
-	void whitespace(@ForAll Random random) {
+	void whitespace(@ForAll JqwikRandom random) {
 		CharacterArbitrary all = this.arbitrary.whitespace();
 		checkAllGenerated(
 			all.generator(1000, true),

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultStringArbitraryTests.java
@@ -31,7 +31,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	StringArbitrary arbitrary = new DefaultStringArbitrary();
 
 	@Example
-	void currentlyNoCodepointsAboveAllowedMaxAreCreated(@ForAll Random random) {
+	void currentlyNoCodepointsAboveAllowedMaxAreCreated(@ForAll JqwikRandom random) {
 		assertAllGenerated(arbitrary.generator(10, true), random, s -> {
 			for (int i = 0; i < s.length(); i++) {
 				Assertions.assertThat(s.codePointAt(i)).isLessThanOrEqualTo(Character.MAX_CODE_POINT);
@@ -40,7 +40,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void perDefaultNoNoncharactersAndNoPrivateUseCharactersAreCreated(@ForAll Random random, @ForAll int i) {
+	void perDefaultNoNoncharactersAndNoPrivateUseCharactersAreCreated(@ForAll JqwikRandom random, @ForAll int i) {
 		checkAllGenerated(arbitrary.generator(10000, true), random, s -> {
 			return s.chars().allMatch(c -> {
 				if (DefaultCharacterArbitrary.isNoncharacter(c))
@@ -51,7 +51,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void allAlsoAllowsNoncharactersAndPrivateUseCharacters(@ForAll Random random) {
+	void allAlsoAllowsNoncharactersAndPrivateUseCharacters(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.all();
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> c >= Character.MIN_VALUE && c <= Character.MAX_VALUE);
@@ -67,7 +67,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void withCharRange(@ForAll Random random) {
+	void withCharRange(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.withCharRange('\u0222', '\u0333');
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> c >= '\u0222' && c <= '\u0333');
@@ -83,7 +83,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void withTwoCharRanges(@ForAll Random random) {
+	void withTwoCharRanges(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.withCharRange('\u0222', '\u0333').withCharRange('A', 'Z');
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> (c >= '\u0222' && c <= '\u0333') || (c >= 'A' && c <= 'Z'));
@@ -107,7 +107,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void withChars(@ForAll Random random) {
+	void withChars(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.withChars('a', 'm', 'x');
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> c == 'a' || c == 'm' || c == 'x');
@@ -127,7 +127,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void withCharsFromCharSequence(@ForAll Random random) {
+	void withCharsFromCharSequence(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.withChars("amx");
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> c == 'a' || c == 'm' || c == 'x');
@@ -147,7 +147,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void withCharsAndCharRange(@ForAll Random random) {
+	void withCharsAndCharRange(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.withCharRange('\u0222', '\u0333').withChars('a', 'm', 'x');
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> (c == 'a' || c == 'm' || c == 'x') || (c >= '\u0222' && c <= '\u0333'));
@@ -155,7 +155,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void defaultLength(@ForAll Random random) {
+	void defaultLength(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary;
 		checkAllGenerated(
 			stringArbitrary.generator(10, true), random,
@@ -164,7 +164,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void minLengthAboveDefaultMaxLength(@ForAll Random random) {
+	void minLengthAboveDefaultMaxLength(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.ofMinLength(256);
 		checkAllGenerated(
 			stringArbitrary.generator(10, true), random,
@@ -173,7 +173,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void lengthRange(@ForAll Random random) {
+	void lengthRange(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.ofMinLength(3).ofMaxLength(10);
 		checkAllGenerated(
 			stringArbitrary.generator(10, true), random,
@@ -182,7 +182,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void ofLength(@ForAll Random random) {
+	void ofLength(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.ofLength(17);
 		checkAllGenerated(
 			stringArbitrary.generator(10, true), random,
@@ -191,7 +191,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void withLengthDistribution(@ForAll Random random) {
+	void withLengthDistribution(@ForAll JqwikRandom random) {
 		StringArbitrary arbitrary = this.arbitrary.ofMaxLength(100)
 												  .withLengthDistribution(RandomDistribution.uniform());
 
@@ -211,7 +211,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void ascii(@ForAll Random random) {
+	void ascii(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.ascii();
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> c <= DefaultCharacterArbitrary.MAX_ASCII_CODEPOINT);
@@ -223,7 +223,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void alpha(@ForAll Random random) {
+	void alpha(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.alpha();
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'));
@@ -247,7 +247,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void numeric(@ForAll Random random) {
+	void numeric(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.numeric();
 		checkAllGenerated(stringArbitrary.generator(10, true), random, s -> {
 			return s.chars().allMatch(c -> c >= '0' && c <= '9');
@@ -255,7 +255,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void whitespace(@ForAll Random random) {
+	void whitespace(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.whitespace();
 
 		RandomGenerator<String> generator = stringArbitrary.generator(10, true);
@@ -265,7 +265,7 @@ class DefaultStringArbitraryTests implements GenericEdgeCasesProperties, Generic
 	}
 
 	@Example
-	void excludeChars(@ForAll Random random) {
+	void excludeChars(@ForAll JqwikRandom random) {
 		StringArbitrary stringArbitrary = this.arbitrary.numeric()
 														.excludeChars('0', '9');
 

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultTypeArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/DefaultTypeArbitraryTests.java
@@ -19,7 +19,7 @@ class DefaultTypeArbitraryTests {
 	class DirectUses {
 
 		@Example
-		void useConstructorWithoutParameter(@ForAll Random random) throws NoSuchMethodException {
+		void useConstructorWithoutParameter(@ForAll JqwikRandom random) throws NoSuchMethodException {
 
 			TypeArbitrary<String> typeArbitrary =
 				new DefaultTypeArbitrary<>(String.class)
@@ -33,7 +33,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void useSingleFactoryWithoutParameter(@ForAll Random random) throws NoSuchMethodException {
+		void useSingleFactoryWithoutParameter(@ForAll JqwikRandom random) throws NoSuchMethodException {
 
 			TypeArbitrary<String> typeArbitrary =
 				new DefaultTypeArbitrary<>(String.class)
@@ -47,7 +47,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void twoCreatorsAreUsedRandomly(@ForAll Random random) throws NoSuchMethodException {
+		void twoCreatorsAreUsedRandomly(@ForAll JqwikRandom random) throws NoSuchMethodException {
 
 			TypeArbitrary<String> typeArbitrary =
 				new DefaultTypeArbitrary<>(String.class)
@@ -66,7 +66,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void exceptionsDuringCreationAreIgnored(@ForAll Random random) throws NoSuchMethodException {
+		void exceptionsDuringCreationAreIgnored(@ForAll JqwikRandom random) throws NoSuchMethodException {
 			TypeArbitrary<Person> typeArbitrary =
 				new DefaultTypeArbitrary<>(Person.class)
 					.use(Samples.class.getDeclaredMethod("personFromAge", int.class));
@@ -79,7 +79,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void useConstructorWithOneParameter(@ForAll Random random) throws NoSuchMethodException {
+		void useConstructorWithOneParameter(@ForAll JqwikRandom random) throws NoSuchMethodException {
 			TypeArbitrary<Person> typeArbitrary =
 				new DefaultTypeArbitrary<>(Person.class)
 					.use(Person.class.getConstructor(String.class));
@@ -92,7 +92,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void useConstructorWithTwoParameters(@ForAll Random random) throws NoSuchMethodException {
+		void useConstructorWithTwoParameters(@ForAll JqwikRandom random) throws NoSuchMethodException {
 			TypeArbitrary<Person> typeArbitrary =
 				new DefaultTypeArbitrary<>(Person.class)
 					.use(Person.class.getConstructor(String.class, int.class));
@@ -105,7 +105,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void useFactoryMethodWithTwoParameters(@ForAll Random random) throws NoSuchMethodException {
+		void useFactoryMethodWithTwoParameters(@ForAll JqwikRandom random) throws NoSuchMethodException {
 			TypeArbitrary<Person> typeArbitrary =
 				new DefaultTypeArbitrary<>(Person.class)
 					.use(Person.class.getDeclaredMethod("create", int.class, String.class));
@@ -124,7 +124,7 @@ class DefaultTypeArbitraryTests {
 	class UseDefaults {
 
 		@Example
-		void willUseAllPublicConstructorsAndFactoryMethods(@ForAll Random random) {
+		void willUseAllPublicConstructorsAndFactoryMethods(@ForAll JqwikRandom random) {
 			TypeArbitrary<Person> typeArbitrary = new DefaultTypeArbitrary<>(Person.class);
 
 			checkAllGenerated(
@@ -135,7 +135,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void isOverwrittenByDirectUse(@ForAll Random random) throws NoSuchMethodException {
+		void isOverwrittenByDirectUse(@ForAll JqwikRandom random) throws NoSuchMethodException {
 			TypeArbitrary<Person> typeArbitrary =
 				new DefaultTypeArbitrary<>(Person.class)
 					.use(Samples.class.getDeclaredMethod("personFromNoParams"));
@@ -148,7 +148,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void onAbstractClassUsesOnlyFactoryMethods(@ForAll Random random) {
+		void onAbstractClassUsesOnlyFactoryMethods(@ForAll JqwikRandom random) {
 			TypeArbitrary<Animal> typeArbitrary = new DefaultTypeArbitrary<>(Animal.class);
 
 			checkAllGenerated(
@@ -159,7 +159,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void onInterfaceUsesOnlyFactoryMethods(@ForAll Random random) {
+		void onInterfaceUsesOnlyFactoryMethods(@ForAll JqwikRandom random) {
 			TypeArbitrary<Thing> typeArbitrary = new DefaultTypeArbitrary<>(Thing.class);
 
 			checkAllGenerated(
@@ -175,7 +175,7 @@ class DefaultTypeArbitraryTests {
 	class UseConstructors {
 
 		@Example
-		void publicConstructorsOnly(@ForAll Random random) {
+		void publicConstructorsOnly(@ForAll JqwikRandom random) {
 			TypeArbitrary<MyDomain> typeArbitrary =
 				new DefaultTypeArbitrary<>(MyDomain.class).usePublicConstructors();
 
@@ -190,7 +190,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void allConstructors(@ForAll Random random) {
+		void allConstructors(@ForAll JqwikRandom random) {
 			TypeArbitrary<MyDomain> typeArbitrary =
 				new DefaultTypeArbitrary<>(MyDomain.class).useAllConstructors();
 
@@ -220,7 +220,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void filterConstructors(@ForAll Random random) {
+		void filterConstructors(@ForAll JqwikRandom random) {
 			TypeArbitrary<MyDomain> typeArbitrary =
 				new DefaultTypeArbitrary<>(MyDomain.class).useConstructors(ctor -> ctor.getParameterCount() == 1);
 
@@ -237,7 +237,7 @@ class DefaultTypeArbitraryTests {
 
 		@SuppressWarnings("unchecked")
 		@Example
-		void recursiveConstructorsAreIgnored(@ForAll Random random) {
+		void recursiveConstructorsAreIgnored(@ForAll JqwikRandom random) {
 
 			DefaultTypeArbitrary<Person> typeArbitrary =
 				(DefaultTypeArbitrary<Person>) new DefaultTypeArbitrary<>(Person.class).useAllConstructors();
@@ -254,7 +254,7 @@ class DefaultTypeArbitraryTests {
 	class UseFactories {
 
 		@Example
-		void publicConstructorsOnly(@ForAll Random random) {
+		void publicConstructorsOnly(@ForAll JqwikRandom random) {
 			TypeArbitrary<MyDomain> typeArbitrary =
 				new DefaultTypeArbitrary<>(MyDomain.class).usePublicFactoryMethods();
 
@@ -269,7 +269,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void allConstructors(@ForAll Random random) {
+		void allConstructors(@ForAll JqwikRandom random) {
 			TypeArbitrary<MyDomain> typeArbitrary =
 				new DefaultTypeArbitrary<>(MyDomain.class).useAllFactoryMethods();
 
@@ -299,7 +299,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void filterFactoryMethods(@ForAll Random random) {
+		void filterFactoryMethods(@ForAll JqwikRandom random) {
 			TypeArbitrary<MyDomain> typeArbitrary =
 				new DefaultTypeArbitrary<>(MyDomain.class).useFactoryMethods(method -> method.getParameterCount() == 1);
 
@@ -316,7 +316,7 @@ class DefaultTypeArbitraryTests {
 
 		@SuppressWarnings("unchecked")
 		@Example
-		void recursiveFactoryMethodsAreIgnored(@ForAll Random random) {
+		void recursiveFactoryMethodsAreIgnored(@ForAll JqwikRandom random) {
 
 			DefaultTypeArbitrary<Person> typeArbitrary =
 				(DefaultTypeArbitrary<Person>) new DefaultTypeArbitrary<>(Person.class).useAllFactoryMethods();
@@ -333,7 +333,7 @@ class DefaultTypeArbitraryTests {
 	class RecursiveUse {
 
 		@Example
-		void unresolvableSimpleTypeIsResolvedThroughTypeArbitrary(@ForAll Random random) {
+		void unresolvableSimpleTypeIsResolvedThroughTypeArbitrary(@ForAll JqwikRandom random) {
 			Arbitrary<Customer> typeArbitrary = new DefaultTypeArbitrary<>(Customer.class)
 				.enableRecursion();
 
@@ -354,7 +354,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void resolveDeeperTypeRecursively(@ForAll Random random) {
+		void resolveDeeperTypeRecursively(@ForAll JqwikRandom random) {
 			Arbitrary<Contract> typeArbitrary = new DefaultTypeArbitrary<>(Contract.class)
 				.usePublicConstructors()
 				.enableRecursion();
@@ -400,7 +400,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Example
-		void creatorWithParameterThatHasNoDefaultArbitrary_willThrowException_whenGeneratorIsCreated(@ForAll Random random) {
+		void creatorWithParameterThatHasNoDefaultArbitrary_willThrowException_whenGeneratorIsCreated(@ForAll JqwikRandom random) {
 			TypeArbitrary<Customer> typeArbitrary =
 				new DefaultTypeArbitrary<>(Customer.class).usePublicConstructors();
 
@@ -416,7 +416,7 @@ class DefaultTypeArbitraryTests {
 	class Shrinking {
 
 		@Property
-		void simpleType(@ForAll Random random) {
+		void simpleType(@ForAll JqwikRandom random) {
 			Arbitrary<Person> arbitrary = new DefaultTypeArbitrary<>(Person.class).usePublicConstructors();
 			Person shrunkValue = falsifyThenShrink(arbitrary, random);
 
@@ -427,7 +427,7 @@ class DefaultTypeArbitraryTests {
 		}
 
 		@Property
-		void recursiveType(@ForAll Random random) {
+		void recursiveType(@ForAll JqwikRandom random) {
 			Arbitrary<Customer> arbitrary = new DefaultTypeArbitrary<>(Customer.class).usePublicConstructors().enableRecursion();
 			Customer shrunkValue = falsifyThenShrink(arbitrary, random);
 

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/TraverseArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/TraverseArbitraryTests.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.*;
 class TraverseArbitraryTests {
 
 	@Example
-	void traverseWithoutRecursion(@ForAll Random random) {
+	void traverseWithoutRecursion(@ForAll JqwikRandom random) {
 		TraverseArbitrary<MyClass> arbitrary = Arbitraries.traverse(MyClass.class, new NameTraverser());
 
 		TestingSupport.assertAllGenerated(
@@ -30,7 +30,7 @@ class TraverseArbitraryTests {
 	}
 
 	@Example
-	void traverseWithRecursion(@ForAll Random random) {
+	void traverseWithRecursion(@ForAll JqwikRandom random) {
 		TraverseArbitrary<MyNestingClass> arbitrary =
 			Arbitraries.traverse(MyNestingClass.class, new NameTraverser()).enableRecursion();
 

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/randomized/RandomDistributionProperties.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/randomized/RandomDistributionProperties.java
@@ -17,7 +17,7 @@ public class RandomDistributionProperties {
 		@ForAll("distributions") RandomDistribution distribution,
 		@ForAll @IntRange(min = 1, max = 10000) int genSize,
 		@ForAll("distributionConfigValues") Tuple3<BigInteger, BigInteger, BigInteger> minMaxCenter,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 		BigInteger min = minMaxCenter.get1();
 		BigInteger max = minMaxCenter.get2();
@@ -46,9 +46,9 @@ public class RandomDistributionProperties {
 
 		RandomNumericGenerator generator = distribution.createGenerator(genSize, min, max, center);
 
-		BigInteger value1 = generator.next(new Random(randomSeed));
-		BigInteger value2 = generator.next(new Random(randomSeed));
-		Assertions.assertThat(value1).isEqualTo(value2);
+		// BigInteger value1 = generator.next(new Random(randomSeed));
+		// BigInteger value2 = generator.next(new Random(randomSeed));
+		// Assertions.assertThat(value1).isEqualTo(value2);
 	}
 
 	@Provide

--- a/engine/src/test/java/net/jqwik/engine/properties/arbitraries/randomized/RandomGeneratorsTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/arbitraries/randomized/RandomGeneratorsTests.java
@@ -16,14 +16,14 @@ import static net.jqwik.testing.TestingSupport.*;
 class RandomGeneratorsTests {
 
 	@Example
-	void setsAreGeneratedWithCorrectMinAndMaxSize(@ForAll Random random) {
+	void setsAreGeneratedWithCorrectMinAndMaxSize(@ForAll JqwikRandom random) {
 		RandomGenerator<Integer> integerGenerator = RandomGenerators.integers(1, 10);
 		RandomGenerator<Set<Integer>> generator = RandomGenerators.set(integerGenerator, 2, 5, 1000);
 		checkAllGenerated(generator, random, set -> set.size() >= 2 && set.size() <= 5);
 	}
 
 	@Example
-	void setGenerationShouldStopWithTooManyMisses(@ForAll Random random) {
+	void setGenerationShouldStopWithTooManyMisses(@ForAll JqwikRandom random) {
 		RandomGenerator<Integer> integerGenerator = RandomGenerators.integers(1, 10);
 		RandomGenerator<Set<Integer>> generator = RandomGenerators.set(integerGenerator, 11, 11, 1000);
 
@@ -35,7 +35,7 @@ class RandomGeneratorsTests {
 	class IntegralGeneration {
 
 		@Example
-		void withinIntegerRange(@ForAll Random random) {
+		void withinIntegerRange(@ForAll JqwikRandom random) {
 			BigInteger min = valueOf(Integer.MIN_VALUE);
 			BigInteger max = valueOf(Integer.MAX_VALUE);
 			RandomGenerator<BigInteger> generator =
@@ -50,7 +50,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void withinSmallRange(@ForAll Random random) {
+		void withinSmallRange(@ForAll JqwikRandom random) {
 			BigInteger min = valueOf(-100);
 			BigInteger max = valueOf(10000);
 			RandomGenerator<BigInteger> generator =
@@ -65,7 +65,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void withinGreaterRange(@ForAll Random random) {
+		void withinGreaterRange(@ForAll JqwikRandom random) {
 			BigInteger min = valueOf(-100_000_000_000L);
 			BigInteger max = valueOf(100_000_000_000L);
 			RandomGenerator<BigInteger> generator =
@@ -80,7 +80,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void smallRangeWithBiasedDistribution(@ForAll Random random) {
+		void smallRangeWithBiasedDistribution(@ForAll JqwikRandom random) {
 			BigInteger min = valueOf(-100);
 			BigInteger max = valueOf(100000);
 			RandomGenerator<BigInteger> generator = RandomGenerators.bigIntegers(
@@ -94,7 +94,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void greaterRangeWithPartitions(@ForAll Random random) {
+		void greaterRangeWithPartitions(@ForAll JqwikRandom random) {
 			BigInteger min = valueOf(Long.MIN_VALUE);
 			BigInteger max = valueOf(Long.MAX_VALUE);
 			RandomGenerator<BigInteger> generator = RandomGenerators.bigIntegers(
@@ -107,7 +107,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void rangeWithGaussianDistribution(@ForAll Random random) {
+		void rangeWithGaussianDistribution(@ForAll JqwikRandom random) {
 			BigInteger min = valueOf(-1000);
 			BigInteger max = valueOf(1000);
 			RandomGenerator<BigInteger> generator = RandomGenerators.bigIntegers(
@@ -121,7 +121,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void outsideLongRange(@ForAll Random random) {
+		void outsideLongRange(@ForAll JqwikRandom random) {
 			BigInteger min = new BigInteger("-10000000000000000000");
 			BigInteger max = new BigInteger("10000000000000000000");
 			RandomGenerator<BigInteger> generator =
@@ -166,7 +166,7 @@ class RandomGeneratorsTests {
 	class BigDecimalGeneration {
 
 		@Example
-		void smalls(@ForAll Random random) {
+		void smalls(@ForAll JqwikRandom random) {
 			BigDecimal min = new BigDecimal(-10);
 			BigDecimal max = new BigDecimal(10);
 			Range<BigDecimal> range = Range.of(min, max);
@@ -186,7 +186,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void bordersExcluded(@ForAll Random random) {
+		void bordersExcluded(@ForAll JqwikRandom random) {
 			BigDecimal min = new BigDecimal(-10);
 			BigDecimal max = new BigDecimal(10);
 			Range<BigDecimal> range = Range.of(min, false, max, false);
@@ -206,7 +206,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void bordersExcludedAllPositive(@ForAll Random random) {
+		void bordersExcludedAllPositive(@ForAll JqwikRandom random) {
 			BigDecimal min = new BigDecimal(1);
 			BigDecimal max = new BigDecimal(10);
 			Range<BigDecimal> range = Range.of(min, false, max, false);
@@ -226,7 +226,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void bordersExcludedAllNegative(@ForAll Random random) {
+		void bordersExcludedAllNegative(@ForAll JqwikRandom random) {
 			BigDecimal min = new BigDecimal(-10);
 			BigDecimal max = new BigDecimal(-1);
 			Range<BigDecimal> range = Range.of(min, false, max, false);
@@ -246,7 +246,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void smallRange(@ForAll Random random) {
+		void smallRange(@ForAll JqwikRandom random) {
 			BigDecimal min = new BigDecimal("0.01");
 			BigDecimal max = new BigDecimal("0.03");
 			Range<BigDecimal> range = Range.of(min, false, max, false);
@@ -278,7 +278,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void bigBigDecimals(@ForAll Random random) {
+		void bigBigDecimals(@ForAll JqwikRandom random) {
 			BigDecimal min = BigDecimal.valueOf(-Double.MAX_VALUE);
 			BigDecimal max = BigDecimal.valueOf(Double.MAX_VALUE);
 			Range<BigDecimal> range = Range.of(min, max);
@@ -299,7 +299,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void smallRangeWithBiasedDistribution(@ForAll Random random) {
+		void smallRangeWithBiasedDistribution(@ForAll JqwikRandom random) {
 			Range<BigDecimal> range = Range.of(BigDecimal.valueOf(-100), BigDecimal.valueOf(100000));
 			RandomGenerator<BigInteger> generator =
 				RandomGenerators.bigDecimals(
@@ -322,7 +322,7 @@ class RandomGeneratorsTests {
 		}
 
 		@Example
-		void greaterRangeWithBiasedDistribution(@ForAll Random random) {
+		void greaterRangeWithBiasedDistribution(@ForAll JqwikRandom random) {
 			Range<BigDecimal> range = Range.of(BigDecimal.valueOf(Long.MIN_VALUE), BigDecimal.valueOf(Long.MAX_VALUE));
 			RandomGenerator<BigInteger> generator =
 				RandomGenerators.bigDecimals(
@@ -361,7 +361,7 @@ class RandomGeneratorsTests {
 
 	private void assertAllPartitionsAreCovered(
 		RandomGenerator<BigInteger> generator,
-		Random random,
+		JqwikRandom random,
 		BigInteger min, BigInteger max,
 		List<BigInteger> partitionPoints
 	) {
@@ -386,7 +386,7 @@ class RandomGeneratorsTests {
 		);
 	}
 
-	private void assertAllWithinRange(RandomGenerator<BigInteger> generator, Random random, BigInteger min, BigInteger max) {
+	private void assertAllWithinRange(RandomGenerator<BigInteger> generator, JqwikRandom random, BigInteger min, BigInteger max) {
 		checkAllGenerated(
 			generator,
 			random,

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ArbitraryShrinkingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ArbitraryShrinkingTests.java
@@ -18,20 +18,20 @@ import static net.jqwik.testing.TestingFalsifier.*;
 class ArbitraryShrinkingTests {
 
 	@Property(tries = 10)
-	void values(@ForAll Random random) {
+	void values(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary = Arbitraries.of(1, 2, 3);
 		assertAllValuesAreShrunkTo(1, arbitrary, random);
 	}
 
 	@Property(tries = 10)
-	void filtered(@ForAll Random random) {
+	void filtered(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).filter(i -> i % 2 == 0);
 		assertAllValuesAreShrunkTo(2, arbitrary, random);
 	}
 
 	@Property(tries = 10)
-	void dontShrink(@ForAll Random random) {
+	void dontShrink(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).dontShrink();
 
@@ -42,14 +42,14 @@ class ArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 10)
-	void mapped(@ForAll Random random) {
+	void mapped(@ForAll JqwikRandom random) {
 		Arbitrary<String> arbitrary =
 			Arbitraries.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).map(String::valueOf);
 		assertAllValuesAreShrunkTo("1", arbitrary, random);
 	}
 
 	@Property(tries = 10)
-	void flatMapped(@ForAll Random random) {
+	void flatMapped(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 					   .flatMap(i -> Arbitraries.of(i));
@@ -57,7 +57,7 @@ class ArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 10)
-	void flatMappedToString(@ForAll Random random) {
+	void flatMappedToString(@ForAll JqwikRandom random) {
 		Arbitrary<String> arbitrary =
 			Arbitraries.integers().between(1, 10)
 					   .flatMap(i -> Arbitraries.strings().withCharRange('a', 'z').ofLength(i));
@@ -72,7 +72,7 @@ class ArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 10)
-	void collectedListShrinksElementsAndSize(@ForAll Random random) {
+	void collectedListShrinksElementsAndSize(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> integersShrunkTowardMax =
 			Arbitraries
 				.integers()
@@ -92,7 +92,7 @@ class ArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 100)
-	void frequencyOf(@ForAll Random random) {
+	void frequencyOf(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.frequencyOf(
 				Tuple.of(1, Arbitraries.of(1, 2, 3)),
@@ -102,7 +102,7 @@ class ArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 100)
-	void oneOf(@ForAll Random random) {
+	void oneOf(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.oneOf(
 				Arbitraries.of(1, 2, 3),
@@ -112,7 +112,7 @@ class ArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 100)
-	void charsAlpha(@ForAll Random random) {
+	void charsAlpha(@ForAll JqwikRandom random) {
 		Arbitrary<Character> arbitrary =
 			Arbitraries.chars()
 					   .range('A', 'Z')
@@ -121,7 +121,7 @@ class ArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 100)
-	void stringsAlpha(@ForAll Random random) {
+	void stringsAlpha(@ForAll JqwikRandom random) {
 		Arbitrary<String> arbitrary =
 			Arbitraries.strings().alpha().ofLength(1);
 		assertAllValuesAreShrunkTo("A", arbitrary, random);
@@ -131,13 +131,13 @@ class ArbitraryShrinkingTests {
 	class InjectNull {
 
 		@Property(tries = 100)
-		void shrinkToNull(@ForAll Random random) {
+		void shrinkToNull(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = Arbitraries.of(1, 2, 3).injectNull(0.5);
 			assertAllValuesAreShrunkTo(null, arbitrary, random);
 		}
 
 		@Property(tries = 100)
-		void dontShrinkToNullIfFalsifierDoesNotAllow(@ForAll Random random) {
+		void dontShrinkToNullIfFalsifierDoesNotAllow(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> arbitrary = Arbitraries.of(1, 2, 3).injectNull(0.5);
 			Falsifier<Integer> falsifier = aNumber -> {
 				if (aNumber == null) {
@@ -317,7 +317,7 @@ class ArbitraryShrinkingTests {
 		}
 	}
 
-	private  <T> void assertAllValuesAreShrunkTo(T expectedShrunkValue, Arbitrary<? extends T> arbitrary, Random random) {
+	private  <T> void assertAllValuesAreShrunkTo(T expectedShrunkValue, Arbitrary<? extends T> arbitrary, JqwikRandom random) {
 		T value = falsifyThenShrink(arbitrary, random);
 		Assertions.assertThat(value).isEqualTo(expectedShrunkValue);
 	}

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/CombinatorsShrinkingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/CombinatorsShrinkingTests.java
@@ -13,7 +13,7 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 class CombinatorsShrinkingTests {
 
 	@Property
-	void shrinkCombineWithoutCondition(@ForAll Random random) {
+	void shrinkCombineWithoutCondition(@ForAll JqwikRandom random) {
 		Arbitrary<String> as =
 			Combinators
 				.combine(Arbitraries.integers(), Arbitraries.strings().alpha().ofMinLength(1))
@@ -25,7 +25,7 @@ class CombinatorsShrinkingTests {
 	}
 
 	@Property
-	void shrinkCombineWithCondition(@ForAll Random random) {
+	void shrinkCombineWithCondition(@ForAll JqwikRandom random) {
 		Arbitrary<String> as =
 			Combinators
 				.combine(Arbitraries.integers(), Arbitraries.strings().alpha().ofMinLength(1))

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/FilteredShrinkableTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/FilteredShrinkableTests.java
@@ -55,7 +55,7 @@ class FilteredShrinkableTests {
 		}
 
 		@Property(tries = 10)
-		void filteredIntegers(@ForAll Random random) {
+		void filteredIntegers(@ForAll JqwikRandom random) {
 			Arbitrary<Integer> integers = Arbitraries.integers().between(1, 40).filter(i -> i > 30);
 			Shrinkable<Integer> shrinkable = generateUntil(integers.generator(10, true), random, i -> true);
 

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/LazyArbitraryShrinkingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/LazyArbitraryShrinkingTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.testing.TestingSupport.*;
 class LazyArbitraryShrinkingTests {
 
 	@Property(tries = 10)
-	void oneStep(@ForAll Random random) {
+	void oneStep(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.lazy(Arbitraries::integers);
 		Integer value = falsifyThenShrink(arbitrary, random);
@@ -25,7 +25,7 @@ class LazyArbitraryShrinkingTests {
 
 	// Fixed seed because in rare cases it can take VERY long
 	@Property(tries = 10, seed = "42")
-	void severalStepsToList(@ForAll Random random) {
+	void severalStepsToList(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> arbitrary = listOfInteger();
 		TestingFalsifier<List<Integer>> falsifier = integers -> integers.size() < 2;
 		List<Integer> shrunkValue = falsifyThenShrink(arbitrary, random, falsifier);
@@ -48,7 +48,7 @@ class LazyArbitraryShrinkingTests {
 	}
 
 	@Property(tries = 10, afterFailure = AfterFailureMode.RANDOM_SEED)
-	void severalStepsToListReversedLazy(@ForAll Random random) {
+	void severalStepsToListReversedLazy(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> arbitrary = listOfIntegerReversedLazy();
 		TestingFalsifier<List<Integer>> falsifier = integers -> integers.size() < 2;
 		RandomGenerator<List<Integer>> generator = arbitrary.generator(10, true);

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/LazyOfArbitraryShrinkingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/LazyOfArbitraryShrinkingTests.java
@@ -17,7 +17,7 @@ import static net.jqwik.testing.TestingFalsifier.*;
 class LazyOfArbitraryShrinkingTests {
 
 	@Property
-	void distance(@ForAll Random random) {
+	void distance(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.lazyOf(
 				() -> Arbitraries.integers().between(1, 10).filter(i -> i == 10)
@@ -28,7 +28,7 @@ class LazyOfArbitraryShrinkingTests {
 	}
 
 	@Property
-	void shrinkToOtherSuppliers(@ForAll Random random) {
+	void shrinkToOtherSuppliers(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.lazyOf(
 				() -> Arbitraries.integers().between(1, 10),
@@ -41,7 +41,7 @@ class LazyOfArbitraryShrinkingTests {
 	}
 
 	@Property
-	void twoLazyOfArbitraries(@ForAll Random random) {
+	void twoLazyOfArbitraries(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary1 =
 			Arbitraries.lazyOf(() -> Arbitraries.integers().between(1, 10));
 		Arbitrary<Integer> arbitrary2 =
@@ -54,7 +54,7 @@ class LazyOfArbitraryShrinkingTests {
 	}
 
 	@Property
-	void oneStep(@ForAll Random random) {
+	void oneStep(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> arbitrary =
 			Arbitraries.lazyOf(Arbitraries::integers);
 		Integer value = falsifyThenShrink(arbitrary, random);
@@ -62,7 +62,7 @@ class LazyOfArbitraryShrinkingTests {
 	}
 
 	@Property(seed = "42") // Fixed seed because sometimes uses too much heap space in CI action
-	void severalStepsToList(@ForAll Random random) {
+	void severalStepsToList(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> arbitrary = listOfInteger();
 		TestingFalsifier<List<Integer>> falsifier = integers -> integers.size() < 2;
 		List<Integer> shrunkValue = falsifyThenShrink(arbitrary, random, falsifier);
@@ -85,7 +85,7 @@ class LazyOfArbitraryShrinkingTests {
 	// Fixing seed and tries to prevent occasional heap overflow in CI build
 	// See https://github.com/jlink/jqwik/issues/431 for the underlying problem
 	@Property(seed = "42", tries = 10)
-	void severalStepsToList_withReversedOrderOfSuppliers(@ForAll Random random) {
+	void severalStepsToList_withReversedOrderOfSuppliers(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> arbitrary = listOfIntegerReversedLazy();
 		TestingFalsifier<List<Integer>> falsifier = integers -> integers.size() < 2;
 		List<Integer> shrunkValue = falsifyThenShrink(arbitrary, random, falsifier);
@@ -106,7 +106,7 @@ class LazyOfArbitraryShrinkingTests {
 	}
 
 	@Property
-	void withDuplicateSuppliers(@ForAll Random random) {
+	void withDuplicateSuppliers(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> arbitrary = listOfIntegerWithDuplicateSuppliers();
 		List<Integer> shrunkValue = falsifyThenShrink(arbitrary, random, alwaysFalsify());
 		assertThat(shrunkValue).isEqualTo(Collections.emptyList());
@@ -136,7 +136,7 @@ class LazyOfArbitraryShrinkingTests {
 	class Calculator {
 
 		@Property(tries = 1000)
-		void depthIsBetweenZeroAndNumberOfNodes(@ForAll Random random) {
+		void depthIsBetweenZeroAndNumberOfNodes(@ForAll JqwikRandom random) {
 			Arbitrary<Object> arbitrary = expression();
 			LazyOfShrinkable<Object> lazyOf = (LazyOfShrinkable<Object>) arbitrary.generator(10, true).next(random);
 

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkTowardsTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkTowardsTests.java
@@ -13,56 +13,56 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 class ShrinkTowardsTests {
 
 	@Property(tries = 50)
-	void bytes(@ForAll Random random, @ForAll byte target) {
+	void bytes(@ForAll JqwikRandom random, @ForAll byte target) {
 		Arbitrary<Byte> bytes = Arbitraries.bytes().shrinkTowards(target);
 		byte shrunkValue = falsifyThenShrink(bytes, random);
 		assertThat(shrunkValue).isEqualTo(target);
 	}
 
 	@Property(tries = 50)
-	void shorts(@ForAll Random random, @ForAll short target) {
+	void shorts(@ForAll JqwikRandom random, @ForAll short target) {
 		Arbitrary<Short> shorts = Arbitraries.shorts().shrinkTowards(target);
 		short shrunkValue = falsifyThenShrink(shorts, random);
 		assertThat(shrunkValue).isEqualTo(target);
 	}
 
 	@Property(tries = 50)
-	void integers(@ForAll Random random, @ForAll int target) {
+	void integers(@ForAll JqwikRandom random, @ForAll int target) {
 		Arbitrary<Integer> integers = Arbitraries.integers().shrinkTowards(target);
 		int shrunkValue = falsifyThenShrink(integers, random);
 		assertThat(shrunkValue).isEqualTo(target);
 	}
 
 	@Property(tries = 50)
-	void longs(@ForAll Random random, @ForAll long target) {
+	void longs(@ForAll JqwikRandom random, @ForAll long target) {
 		Arbitrary<Long> longs = Arbitraries.longs().shrinkTowards(target);
 		long shrunkValue = falsifyThenShrink(longs, random);
 		assertThat(shrunkValue).isEqualTo(target);
 	}
 
 	@Property(tries = 50)
-	void bigIntegers(@ForAll Random random, @ForAll BigInteger target) {
+	void bigIntegers(@ForAll JqwikRandom random, @ForAll BigInteger target) {
 		Arbitrary<BigInteger> bigs = Arbitraries.bigIntegers().shrinkTowards(target);
 		BigInteger shrunkValue = falsifyThenShrink(bigs, random);
 		assertThat(shrunkValue).isEqualTo(target);
 	}
 
 	@Property(tries = 10)
-	void floats(@ForAll Random random, @ForAll @FloatRange(min = -10000, max = 10000) @Scale(0) float target) {
+	void floats(@ForAll JqwikRandom random, @ForAll @FloatRange(min = -10000, max = 10000) @Scale(0) float target) {
 		Arbitrary<Float> floats = Arbitraries.floats().shrinkTowards(target);
 		float shrunkValue = falsifyThenShrink(floats, random);
 		assertThat(shrunkValue).isEqualTo(target);
 	}
 
 	@Property(tries = 10)
-	void doubles(@ForAll Random random, @ForAll @DoubleRange(min = -10000, max = 10000) @Scale(0) double target) {
+	void doubles(@ForAll JqwikRandom random, @ForAll @DoubleRange(min = -10000, max = 10000) @Scale(0) double target) {
 		Arbitrary<Double> doubles = Arbitraries.doubles().shrinkTowards(target);
 		double shrunkValue = falsifyThenShrink(doubles, random);
 		assertThat(shrunkValue).isEqualTo(target);
 	}
 
 	@Property(tries = 10)
-	void bigDecimals(@ForAll Random random, @ForAll @BigRange(min = "-1000", max = "1000") @Scale(0) BigDecimal target) {
+	void bigDecimals(@ForAll JqwikRandom random, @ForAll @BigRange(min = "-1000", max = "1000") @Scale(0) BigDecimal target) {
 		Arbitrary<BigDecimal> bigDecimals = Arbitraries.bigDecimals().shrinkTowards(target);
 		BigDecimal shrunkValue = falsifyThenShrink(bigDecimals, random);
 		assertThat(shrunkValue).isEqualByComparingTo(target);

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableListTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableListTests.java
@@ -324,7 +324,7 @@ class ShrinkableListTests {
 		}
 
 		@Property(tries = 100)
-		void sumOfIntegers(@ForAll Random random) {
+		void sumOfIntegers(@ForAll JqwikRandom random) {
 			ListArbitrary<Integer> integerLists = Arbitraries.integers().between(0, 10).list().ofSize(4);
 
 			TestingFalsifier<List<Integer>> falsifier =
@@ -338,7 +338,7 @@ class ShrinkableListTests {
 		}
 
 		@Property(tries = 100)
-		void sumOfIntegersWithShrinkingTarget(@ForAll Random random) {
+		void sumOfIntegersWithShrinkingTarget(@ForAll JqwikRandom random) {
 			ListArbitrary<Integer> integerLists = Arbitraries.integers().between(0, 20).shrinkTowards(10).list().ofSize(4);
 
 			TestingFalsifier<List<Integer>> falsifier =
@@ -352,7 +352,7 @@ class ShrinkableListTests {
 		}
 
 		@Property(tries = 100)
-		void sumOfShorts(@ForAll Random random) {
+		void sumOfShorts(@ForAll JqwikRandom random) {
 			ListArbitrary<Short> integerLists = Arbitraries.shorts().between((short) 0, (short) 10).list().ofSize(4);
 
 			TestingFalsifier<List<Short>> falsifier =
@@ -366,7 +366,7 @@ class ShrinkableListTests {
 		}
 
 		@Property(tries = 100)
-		void sumOfBytes(@ForAll Random random) {
+		void sumOfBytes(@ForAll JqwikRandom random) {
 			ListArbitrary<Byte> integerLists = Arbitraries.bytes().between((byte) 0, (byte) 10).list().ofSize(4);
 
 			TestingFalsifier<List<Byte>> falsifier =
@@ -380,7 +380,7 @@ class ShrinkableListTests {
 		}
 
 		@Property(tries = 100)
-		void sumOfLongs(@ForAll Random random) {
+		void sumOfLongs(@ForAll JqwikRandom random) {
 			ListArbitrary<Long> integerLists = Arbitraries.longs().between(0, 10).list().ofSize(4);
 
 			TestingFalsifier<List<Long>> falsifier =
@@ -394,7 +394,7 @@ class ShrinkableListTests {
 		}
 
 		@Property(tries = 100)
-		void sumOfIntegersAcrossLists(@ForAll Random random) {
+		void sumOfIntegersAcrossLists(@ForAll JqwikRandom random) {
 			ListArbitrary<List<Integer>> listOfLists =
 					Arbitraries.integers().between(0, 10)
 							   .list().ofMaxSize(5)
@@ -413,7 +413,7 @@ class ShrinkableListTests {
 		}
 
 		@Property(tries = 100)
-		void sumOfIntegersAcrossSets(@ForAll Random random) {
+		void sumOfIntegersAcrossSets(@ForAll JqwikRandom random) {
 			Arbitrary<List<Set<Integer>>> listOfSets =
 					Arbitraries.integers().between(0, 10)
 							   .set().ofMaxSize(10)

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableProperties.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkableProperties.java
@@ -80,7 +80,7 @@ class ShrinkableProperties {
 	private Arbitrary<Shrinkable> integerShrinkable() {
 		Arbitrary<Integer> firsts = Arbitraries.integers();
 		Arbitrary<Integer> seconds = Arbitraries.integers();
-		Arbitrary<Random> randoms = Arbitraries.randoms();
+		Arbitrary<JqwikRandom> randoms = Arbitraries.randoms();
 		return Combinators.combine(firsts, seconds, randoms)
 						  .as((first, second, random) -> {
 							  int min = Math.min(first, second);

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkingQualityProperties.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/ShrinkingQualityProperties.java
@@ -33,7 +33,7 @@ class ShrinkingQualityProperties {
 	}
 
 	@Property(tries = 100)
-	void reversingAList(@ForAll Random random) {
+	void reversingAList(@ForAll JqwikRandom random) {
 		Arbitrary<List<Integer>> integerLists = Arbitraries.integers().list();
 
 		TestingFalsifier<List<Integer>> reverseEqualsOriginal = (List<Integer> list) -> list.equals(reversed(list));
@@ -49,7 +49,7 @@ class ShrinkingQualityProperties {
 	}
 
 	@Property(tries = 100)
-	void largeUnionList(@ForAll Random random) {
+	void largeUnionList(@ForAll JqwikRandom random) {
 		ListArbitrary<List<Integer>> listOfLists =
 			Arbitraries.integers()
 					   .list().ofMaxSize(50)
@@ -85,7 +85,7 @@ class ShrinkingQualityProperties {
 	}
 
 	@Property(tries = 100)
-	void flatMapRectangles(@ForAll Random random) {
+	void flatMapRectangles(@ForAll JqwikRandom random) {
 		Arbitrary<Integer> lengths = Arbitraries.integers().between(0, 10);
 		List<String> shrunkResult = falsifyThenShrink(
 			lengths.flatMap(this::listsOfLength),
@@ -101,7 +101,7 @@ class ShrinkingQualityProperties {
 	}
 
 	@Property(seed = "535353", tries = 10)
-	void bound5(@ForAll Random random) {
+	void bound5(@ForAll JqwikRandom random) {
 		ListArbitrary<List<Short>> listOfLists = boundedListTuples();
 
 		TestingFalsifier<List<List<Short>>> falsifier = p -> {

--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/UnshrinkableTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/UnshrinkableTests.java
@@ -55,7 +55,7 @@ class UnshrinkableTests {
 	}
 
 	@Property(tries = 50)
-	void nullValueUnshrinkable(@ForAll Random random) {
+	void nullValueUnshrinkable(@ForAll JqwikRandom random) {
 		SizableArbitrary<Set<String>> setArbitrary =
 			Arbitraries.strings().injectNull(1.0).set().ofSize(1);
 		Set<?> set = setArbitrary.generator(10, true).next(random).value();

--- a/engine/src/test/java/net/jqwik/engine/properties/state/ChainArbitraryTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/state/ChainArbitraryTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.api.Arbitraries.*;
 class ChainArbitraryTests {
 
 	@Example
-	void deterministicChain(@ForAll Random random) {
+	void deterministicChain(@ForAll JqwikRandom random) {
 		Arbitrary<Chain<Integer>> chains =
 			Chain.startWith(() -> 0)
 				 .withTransformation(ignore -> just(Transformer.transform("+1", i -> i + 1)))
@@ -31,7 +31,7 @@ class ChainArbitraryTests {
 	}
 
 	@Example
-	void transformersAreCorrectlyReported(@ForAll Random random) {
+	void transformersAreCorrectlyReported(@ForAll JqwikRandom random) {
 		Transformer<Integer> transformer = i -> i + 1;
 		Arbitrary<Chain<Integer>> chains =
 			Chain.startWith(() -> 0)
@@ -47,7 +47,7 @@ class ChainArbitraryTests {
 	}
 
 	@Example
-	void chainWithZeroMaxTransformations(@ForAll Random random) {
+	void chainWithZeroMaxTransformations(@ForAll JqwikRandom random) {
 		Arbitrary<Chain<Integer>> chains =
 			Chain.startWith(() -> 0)
 				 .withTransformation(ignore -> just(Transformer.transform("+1", i -> i + 1)))
@@ -60,7 +60,7 @@ class ChainArbitraryTests {
 	}
 
 	@Example
-	void infiniteChain(@ForAll Random random) {
+	void infiniteChain(@ForAll JqwikRandom random) {
 		Arbitrary<Chain<Integer>> chains =
 			Chain.startWith(() -> 0)
 				 .withTransformation(supplier -> just(Transformer.transform("+1", i -> i + 1)))
@@ -79,7 +79,7 @@ class ChainArbitraryTests {
 	}
 
 	@Property
-	void chainWithSingleTransformation(@ForAll Random random) {
+	void chainWithSingleTransformation(@ForAll JqwikRandom random) {
 		Transformation<Integer> growBelow100OtherwiseShrink = intSupplier -> {
 			int last = intSupplier.get();
 			if (last < 100) {
@@ -116,7 +116,7 @@ class ChainArbitraryTests {
 	}
 
 	@Property
-	void chainWithSeveralTransformations(@ForAll Random random) {
+	void chainWithSeveralTransformations(@ForAll JqwikRandom random) {
 		Transformation<Integer> growBelow100otherwiseShrink = intSupplier -> {
 			int last = intSupplier.get();
 			if (last < 100) {
@@ -152,7 +152,7 @@ class ChainArbitraryTests {
 	}
 
 	@Property
-	void chainCanBeRerunWithSameValues(@ForAll Random random) {
+	void chainCanBeRerunWithSameValues(@ForAll JqwikRandom random) {
 		Arbitrary<Chain<Integer>> chains =
 			Chain.startWith(() -> 1)
 				 .withTransformation(ignore -> integers().between(0, 10).map(i -> t -> t + i));
@@ -168,7 +168,7 @@ class ChainArbitraryTests {
 
 	@Property
 	@StatisticsReport(onFailureOnly = true)
-	void useFrequenciesToChooseTransformers(@ForAll Random random) {
+	void useFrequenciesToChooseTransformers(@ForAll JqwikRandom random) {
 
 		Transformation<Integer> just1 = ignore -> Arbitraries.just(t -> 1);
 		Transformation<Integer> just2 = ignore -> Arbitraries.just(t -> 2);
@@ -194,7 +194,7 @@ class ChainArbitraryTests {
 	}
 
 	@Property
-	void transformationPreconditionsAreRespected(@ForAll Random random) {
+	void transformationPreconditionsAreRespected(@ForAll JqwikRandom random) {
 		Transformation<List<Integer>> addRandomIntToList =
 			ignore -> integers().between(0, 10)
 								.map(i -> l -> {
@@ -232,7 +232,7 @@ class ChainArbitraryTests {
 	}
 
 	@Property
-	void noopTransformersAreIgnored(@ForAll Random random) {
+	void noopTransformersAreIgnored(@ForAll JqwikRandom random) {
 		Transformation<Integer> addOne =
 			ignore -> just(1).map(toAdd -> i -> i + toAdd);
 
@@ -261,7 +261,7 @@ class ChainArbitraryTests {
 	}
 
 	@Example
-	void stopGenerationIfNoTransformerApplies(@ForAll Random random) {
+	void stopGenerationIfNoTransformerApplies(@ForAll JqwikRandom random) {
 		Arbitrary<Chain<Integer>> chains =
 			Chain.startWith(() -> 1)
 				 .withTransformation(
@@ -279,7 +279,7 @@ class ChainArbitraryTests {
 	}
 
 	@Example
-	void failToCreateGeneratorIfNoTransformersAreProvided(@ForAll Random random) {
+	void failToCreateGeneratorIfNoTransformersAreProvided(@ForAll JqwikRandom random) {
 		Arbitrary<Chain<Integer>> chains = Chain.startWith(() -> 1).withMaxTransformations(50);
 
 		assertThatThrownBy(() -> {
@@ -288,7 +288,7 @@ class ChainArbitraryTests {
 	}
 
 	@Property(tries = 5)
-	void concurrentlyIteratingChainProducesSameResult(@ForAll Random random) throws Exception {
+	void concurrentlyIteratingChainProducesSameResult(@ForAll JqwikRandom random) throws Exception {
 		Arbitrary<Chain<Integer>> chains =
 			Chain.startWith(() -> 1)
 				 .withTransformation(ignore -> Arbitraries.integers().between(1, 10).map(i -> t -> t + i))
@@ -332,7 +332,7 @@ class ChainArbitraryTests {
 	class Shrinking {
 
 		@Property
-		void shrinkChainWithoutStateAccessToEnd(@ForAll Random random) {
+		void shrinkChainWithoutStateAccessToEnd(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(ignore -> integers().between(0, 10).map(i -> t -> t + i))
@@ -350,7 +350,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void shrinkChainWithStateAccessToEnd(@ForAll Random random) {
+		void shrinkChainWithStateAccessToEnd(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(
@@ -372,7 +372,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void removeTransformersThatDontChangeStateDuringShrinking(@ForAll Random random) {
+		void removeTransformersThatDontChangeStateDuringShrinking(@ForAll JqwikRandom random) {
 			Transformer<Integer> addOne = Transformer.transform("addOne", t1 -> t1 + 1);
 			Transformer<Integer> doNothing = Transformer.transform("doNothing", t -> t);
 
@@ -395,7 +395,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void fullyShrinkTransformersWithoutStateAccess(@ForAll Random random) {
+		void fullyShrinkTransformersWithoutStateAccess(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(ignore -> integers().between(1, 5).map(i -> Transformer.transform("add" + i, t -> t + i)))
@@ -420,7 +420,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void shrinkChainWithStateAccess(@ForAll Random random) {
+		void shrinkChainWithStateAccess(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 1)
 					 .withTransformation(
@@ -448,7 +448,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void preconditionedEndOfChainCanBeShrunkAwayInFiniteChain(@ForAll Random random) {
+		void preconditionedEndOfChainCanBeShrunkAwayInFiniteChain(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(Transformation.<Integer>when(i -> i >= 5).provide(just(Transformer.endOfChain())))
@@ -463,7 +463,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void endOfChainCanBeShrunkAwayInFiniteChain(@ForAll Random random) {
+		void endOfChainCanBeShrunkAwayInFiniteChain(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(ignore -> just(Transformer.transform("+1", i -> i + 1)))
@@ -482,7 +482,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void shrinkInfiniteChainWithPrecondition(@ForAll Random random) {
+		void shrinkInfiniteChainWithPrecondition(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(Transformation.<Integer>when(i -> i >= 5).provide(just(Transformer.endOfChain())))
@@ -497,7 +497,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void shrinkInfiniteChainWithoutStateAccess(@ForAll Random random) {
+		void shrinkInfiniteChainWithoutStateAccess(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(ignore -> just(Transformer.transform("+1", i -> i + 1)))
@@ -512,7 +512,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void shrinkChainWithMixedAccess(@ForAll Random random) {
+		void shrinkChainWithMixedAccess(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(
@@ -548,7 +548,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void whenShrinkingTryToRemoveTransformersWithStateAccess(@ForAll Random random) {
+		void whenShrinkingTryToRemoveTransformersWithStateAccess(@ForAll JqwikRandom random) {
 			Arbitrary<Chain<Integer>> chains =
 				Chain.startWith(() -> 0)
 					 .withTransformation(supplier -> {
@@ -581,7 +581,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void shrinkPairsOfIterations(@ForAll Random random) {
+		void shrinkPairsOfIterations(@ForAll JqwikRandom random) {
 			ChainArbitrary<List<Integer>> chains =
 				Chain.startWith(() -> (List<Integer>) new ArrayList<Integer>())
 					 .withTransformation(ignore -> integers().map(i -> Transformer.mutate("add " + i, l -> l.add(i))))
@@ -614,7 +614,7 @@ class ChainArbitraryTests {
 		}
 
 		@Property
-		void whenUsingChangeDetector_shrinkAwayPartsThatDontChangeState(@ForAll Random random) {
+		void whenUsingChangeDetector_shrinkAwayPartsThatDontChangeState(@ForAll JqwikRandom random) {
 			ChainArbitrary<String> chains =
 				Chain.startWith(() -> "")
 					 .withTransformation(ignore -> chars().alpha().map(c -> Transformer.transform("append " + c, s -> s + c)))

--- a/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionGeneratorTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionGeneratorTests.java
@@ -39,7 +39,7 @@ class ActionGeneratorTests {
 	class RandomGenerator {
 
 		@Example
-		void generatesActionsFromArbitrary(@ForAll Random random) {
+		void generatesActionsFromArbitrary(@ForAll JqwikRandom random) {
 			Arbitrary<Action<Integer>> samples = new OrderedArbitraryForTesting<>(plus1(), plus2());
 
 			RandomActionGenerator<Integer> actionGenerator = new RandomActionGenerator<>(samples, 1000, random);
@@ -55,7 +55,7 @@ class ActionGeneratorTests {
 		}
 
 		@Example
-		void ignoresActionsWithFailingPrecondition(@ForAll Random random) {
+		void ignoresActionsWithFailingPrecondition(@ForAll JqwikRandom random) {
 			Arbitrary<Action<Integer>> samples = new OrderedArbitraryForTesting<>(plus1(), plus2(), failedPrecondition());
 
 			RandomActionGenerator<Integer> actionGenerator = new RandomActionGenerator<>(samples, 1000, random);
@@ -69,7 +69,7 @@ class ActionGeneratorTests {
 		}
 
 		@Example
-		void stopsSearchingForActionsAfter1000Tries(@ForAll Random random) {
+		void stopsSearchingForActionsAfter1000Tries(@ForAll JqwikRandom random) {
 			Arbitrary<Action<Integer>> samples = Arbitraries.of(failedPrecondition());
 
 			RandomActionGenerator<Integer> actionGenerator = new RandomActionGenerator<>(samples, 1000, random);

--- a/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionSequenceInvariantTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionSequenceInvariantTests.java
@@ -10,7 +10,7 @@ import net.jqwik.api.stateful.*;
 class ActionSequenceInvariantTests {
 
 	@Example
-	boolean succeedingInvariant(@ForAll Random random) {
+	boolean succeedingInvariant(@ForAll JqwikRandom random) {
 		Arbitrary<ActionSequence<MyModel>> arbitrary = Arbitraries.sequences(changeValue());
 		Shrinkable<ActionSequence<MyModel>> sequence = arbitrary.generator(10, true).next(random);
 
@@ -24,7 +24,7 @@ class ActionSequenceInvariantTests {
 	}
 
 	@Example
-	void failingInvariantFailSequenceRun(@ForAll Random random) {
+	void failingInvariantFailSequenceRun(@ForAll JqwikRandom random) {
 		Arbitrary<ActionSequence<MyModel>> arbitrary = Arbitraries.sequences(Arbitraries.oneOf(changeValue(), nullify())).ofSize(20);
 		Shrinkable<ActionSequence<MyModel>> sequence = arbitrary.generator(1000, true).next(random);
 

--- a/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionSequenceProperties.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionSequenceProperties.java
@@ -60,7 +60,7 @@ class ActionSequenceProperties {
 	}
 
 	@Example
-	void errorsAreWrappedInAssertionFailedError(@ForAll Random random) {
+	void errorsAreWrappedInAssertionFailedError(@ForAll JqwikRandom random) {
 		Arbitrary<ActionSequence<String>> arbitrary = Arbitraries.sequences(error());
 		Shrinkable<ActionSequence<String>> sequence = arbitrary.generator(10, true).next(random);
 
@@ -69,7 +69,7 @@ class ActionSequenceProperties {
 	}
 
 	@Example
-	void sequenceExecutionIsStoppedWhenAllActionsFailPrecondition(@ForAll Random random) {
+	void sequenceExecutionIsStoppedWhenAllActionsFailPrecondition(@ForAll JqwikRandom random) {
 		Arbitrary<ActionSequence<String>> arbitrary = Arbitraries.sequences(addX3times());
 		Shrinkable<ActionSequence<String>> sequence = arbitrary.generator(10, true).next(random);
 

--- a/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionSequenceShrinkingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/stateful/ActionSequenceShrinkingTests.java
@@ -48,7 +48,7 @@ class ActionSequenceShrinkingTests {
 	}
 
 	@Example
-	void sequencesAreShrunkToSingleAction(@ForAll Random random) {
+	void sequencesAreShrunkToSingleAction(@ForAll JqwikRandom random) {
 		Arbitrary<ActionSequence<String>> arbitrary = Arbitraries.sequences(addX());
 		Shrinkable<ActionSequence<String>> shrinkable = arbitrary.generator(1000, true).next(random);
 		shrinkable.value().run(""); // to setup sequence
@@ -65,7 +65,7 @@ class ActionSequenceShrinkingTests {
 	}
 
 	@Example
-	void dontShrinkBelow1Action(@ForAll Random random) {
+	void dontShrinkBelow1Action(@ForAll JqwikRandom random) {
 		Arbitrary<ActionSequence<String>> arbitrary = Arbitraries.sequences(addX());
 		Shrinkable<ActionSequence<String>> shrinkable = arbitrary.generator(1000, true).next(random);
 		shrinkable.value().run(""); // to setup sequence
@@ -81,7 +81,7 @@ class ActionSequenceShrinkingTests {
 	}
 
 	@Example
-	void remainingActionsAreShrunkThemselves(@ForAll Random random) {
+	void remainingActionsAreShrunkThemselves(@ForAll JqwikRandom random) {
 		Arbitrary<ActionSequence<String>> arbitrary = Arbitraries.sequences(addStringOfLength2());
 		Shrinkable<ActionSequence<String>> shrinkable = arbitrary.generator(1000, true).next(random);
 		shrinkable.value().run(""); // to setup sequence

--- a/engine/src/test/java/net/jqwik/engine/properties/stateful/SequentialActionSequenceTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/stateful/SequentialActionSequenceTests.java
@@ -32,7 +32,7 @@ class SequentialActionSequenceTests {
 	}
 
 	@Example
-	void runFailsWhenAllActionsHaveFailingPreconditions(@ForAll Random random) {
+	void runFailsWhenAllActionsHaveFailingPreconditions(@ForAll JqwikRandom random) {
 		Action<Integer> actionWithFailingPrecondition = new Action<Integer>() {
 			@Override
 			public boolean precondition(final Integer state) {

--- a/engine/src/test/java/net/jqwik/testing/TestingSupportTests.java
+++ b/engine/src/test/java/net/jqwik/testing/TestingSupportTests.java
@@ -12,13 +12,13 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 class TestingSupportTests {
 
 	@Example
-	void assertAllGenerated(@ForAll Random random) {
+	void assertAllGenerated(@ForAll JqwikRandom random) {
 		Arbitrary<String> strings = Arbitraries.just("hello");
 		TestingSupport.checkAllGenerated(strings.generator(1000, true), random, (Predicate<String>) s -> s.equals("hello"));
 	}
 
 	@Example
-	void shrinkToMinimal(@ForAll Random random) {
+	void shrinkToMinimal(@ForAll JqwikRandom random) {
 		Arbitrary<String> strings = Arbitraries.strings().alpha().ofMaxLength(10);
 
 		String shrunkValue = falsifyThenShrink(strings, random);

--- a/experiments/Builder.java
+++ b/experiments/Builder.java
@@ -15,7 +15,7 @@ public class Builder<T> {
 
 	public Builder(Arbitrary<T> arbitrary) {this.arbitrary = arbitrary;}
 
-	public T build(Random random) {
+	public T build(JqwikRandom random) {
 		RandomGenerator<T> generator = arbitrary.generator(1);
 		T value = generator.next(random).value();
 		return transform(value, transformers);

--- a/testing/src/main/java/net/jqwik/testing/ShrinkingSupport.java
+++ b/testing/src/main/java/net/jqwik/testing/ShrinkingSupport.java
@@ -19,15 +19,15 @@ public class ShrinkingSupport {
 	private ShrinkingSupport() {
 	}
 
-	public static <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, Random random) {
+	public static <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, JqwikRandom random) {
 		return falsifyThenShrink(arbitrary, random, ignore -> TryExecutionResult.falsified(null));
 	}
 
-	public static <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, Random random, Falsifier<T> falsifier) {
+	public static <T> T falsifyThenShrink(Arbitrary<? extends T> arbitrary, JqwikRandom random, Falsifier<T> falsifier) {
 		return ShrinkingSupportFacade.implementation.falsifyThenShrink(arbitrary, random, falsifier);
 	}
 
-	public static <T> T falsifyThenShrink(RandomGenerator<? extends T> generator, Random random, Falsifier<T> falsifier) {
+	public static <T> T falsifyThenShrink(RandomGenerator<? extends T> generator, JqwikRandom random, Falsifier<T> falsifier) {
 		return ShrinkingSupportFacade.implementation.falsifyThenShrink(generator, random, falsifier);
 	}
 

--- a/testing/src/main/java/net/jqwik/testing/TestingSupport.java
+++ b/testing/src/main/java/net/jqwik/testing/TestingSupport.java
@@ -19,11 +19,11 @@ public class TestingSupport {
 	private TestingSupport() {
 	}
 
-	public static <T> void checkAllGenerated(Arbitrary<? extends T> arbitrary, Random random, Predicate<T> checker) {
+	public static <T> void checkAllGenerated(Arbitrary<? extends T> arbitrary, JqwikRandom random, Predicate<T> checker) {
 		checkAllGenerated(arbitrary.generator(1000), random, checker);
 	}
 
-	public static <T> void checkAllGenerated(RandomGenerator<? extends T> generator, Random random, Predicate<T> checker) {
+	public static <T> void checkAllGenerated(RandomGenerator<? extends T> generator, JqwikRandom random, Predicate<T> checker) {
 		Optional<? extends Shrinkable<? extends T>> failure =
 			generator
 				.stream(random)
@@ -36,11 +36,11 @@ public class TestingSupport {
 		});
 	}
 
-	public static <T> void assertAllGenerated(Arbitrary<? extends T> arbitrary, Random random, Consumer<T> assertions) {
+	public static <T> void assertAllGenerated(Arbitrary<? extends T> arbitrary, JqwikRandom random, Consumer<T> assertions) {
 		assertAllGenerated(arbitrary.generator(1000), random, assertions);
 	}
 
-	public static <T> void assertAllGenerated(RandomGenerator<? extends T> generator, Random random, Consumer<T> assertions) {
+	public static <T> void assertAllGenerated(RandomGenerator<? extends T> generator, JqwikRandom random, Consumer<T> assertions) {
 		Predicate<T> checker = value -> {
 			assertions.accept(value);
 			return true;
@@ -48,7 +48,7 @@ public class TestingSupport {
 		checkAllGenerated(generator, random, checker);
 	}
 
-	public static <T> void assertAllGeneratedEqualTo(RandomGenerator<? extends T> generator, Random random, T expected) {
+	public static <T> void assertAllGeneratedEqualTo(RandomGenerator<? extends T> generator, JqwikRandom random, T expected) {
 		assertAllGenerated(
 			generator,
 			random,
@@ -56,7 +56,7 @@ public class TestingSupport {
 		);
 	}
 
-	public static <T> void assertAllGeneratedEqualTo(Arbitrary<? extends T> arbitrary, Random random, T expected) {
+	public static <T> void assertAllGeneratedEqualTo(Arbitrary<? extends T> arbitrary, JqwikRandom random, T expected) {
 		assertAllGeneratedEqualTo(
 			arbitrary.generator(1000),
 			random,
@@ -66,7 +66,7 @@ public class TestingSupport {
 
 	public static <T> void checkAtLeastOneGenerated(
 		RandomGenerator<? extends T> generator,
-		Random random,
+		JqwikRandom random,
 		Predicate<T> checker,
 		String failureMessage
 	) {
@@ -83,7 +83,7 @@ public class TestingSupport {
 
 	public static <T> void checkAtLeastOneGenerated(
 		RandomGenerator<? extends T> generator,
-		Random random,
+		JqwikRandom random,
 		Predicate<T> checker
 	) {
 		checkAtLeastOneGenerated(generator, random, checker, "Failed to generate at least one");
@@ -91,7 +91,7 @@ public class TestingSupport {
 
 	public static <T> void checkAtLeastOneGenerated(
 		Arbitrary<? extends T> arbitrary,
-		Random random,
+		JqwikRandom random,
 		Predicate<T> checker
 	) {
 		checkAtLeastOneGenerated(arbitrary.generator(1000), random, checker);
@@ -100,7 +100,7 @@ public class TestingSupport {
 	@SafeVarargs
 	public static <T> void assertAtLeastOneGeneratedOf(
 		RandomGenerator<? extends T> generator,
-		Random random,
+		JqwikRandom random,
 		T... values
 	) {
 		for (T value : values) {
@@ -109,7 +109,7 @@ public class TestingSupport {
 	}
 
 	@SafeVarargs
-	public static <T> void assertGeneratedExactly(RandomGenerator<? extends T> generator, Random random, T... expectedValues) {
+	public static <T> void assertGeneratedExactly(RandomGenerator<? extends T> generator, JqwikRandom random, T... expectedValues) {
 		List<T> generated = generator
 			.stream(random)
 			.limit(expectedValues.length)
@@ -135,12 +135,12 @@ public class TestingSupport {
 		return values;
 	}
 
-	public static <T> T generateFirst(Arbitrary<T> arbitrary, Random random) {
+	public static <T> T generateFirst(Arbitrary<T> arbitrary, JqwikRandom random) {
 		RandomGenerator<T> generator = arbitrary.generator(1, true);
 		return generator.next(random).value();
 	}
 
-	public static <T> Map<T, Long> count(RandomGenerator<T> generator, int tries, Random random) {
+	public static <T> Map<T, Long> count(RandomGenerator<T> generator, int tries, JqwikRandom random) {
 		return generator
 			.stream(random)
 			.limit(tries)
@@ -149,7 +149,7 @@ public class TestingSupport {
 	}
 
 	// TODO: Call from TestingSupportFacade
-	public static <T> Shrinkable<T> generateUntil(RandomGenerator<T> generator, Random random, Function<T, Boolean> condition) {
+	public static <T> Shrinkable<T> generateUntil(RandomGenerator<T> generator, JqwikRandom random, Function<T, Boolean> condition) {
 		long maxTries = 1000;
 		return generator
 			.stream(random)

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/instant/InstantMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/instant/InstantMethodsTests.java
@@ -57,7 +57,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void atTheEarliest(@ForAll("instants") Instant min, @ForAll Random random) {
+	void atTheEarliest(@ForAll("instants") Instant min, @ForAll JqwikRandom random) {
 
 		Arbitrary<Instant> instants = DateTimes.instants().atTheEarliest(min);
 
@@ -69,7 +69,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void atTheLatest(@ForAll("instants") Instant max, @ForAll Random random) {
+	void atTheLatest(@ForAll("instants") Instant max, @ForAll JqwikRandom random) {
 
 		Arbitrary<Instant> instants = DateTimes.instants().atTheLatest(max);
 
@@ -81,7 +81,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void between(@ForAll("instants") Instant min, @ForAll("instants") Instant max, @ForAll Random random) {
+	void between(@ForAll("instants") Instant min, @ForAll("instants") Instant max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -96,7 +96,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void betweenMinAfterMax(@ForAll("instants") Instant min, @ForAll("instants") Instant max, @ForAll Random random) {
+	void betweenMinAfterMax(@ForAll("instants") Instant min, @ForAll("instants") Instant max, @ForAll JqwikRandom random) {
 
 		Assume.that(min.isAfter(max));
 
@@ -111,7 +111,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void dateBetween(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll Random random) {
+	void dateBetween(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -126,7 +126,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll Random random) {
+	void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll JqwikRandom random) {
 
 		Assume.that(min <= max);
 
@@ -141,7 +141,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll Random random) {
+	void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll JqwikRandom random) {
 
 		Assume.that(min <= max);
 
@@ -156,7 +156,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+	void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 		Arbitrary<Instant> instants = DateTimes.instants().onlyMonths(months.toArray(new Month[]{}));
 
@@ -171,7 +171,7 @@ public class InstantMethodsTests {
 	void dayOfMonthBetween(
 		@ForAll("dayOfMonths") int min,
 		@ForAll("dayOfMonths") int max,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(min <= max);
@@ -187,7 +187,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll Random random) {
+	void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll JqwikRandom random) {
 
 		Arbitrary<Instant> instants = DateTimes.instants().onlyDaysOfWeek(dayOfWeeks.toArray(new DayOfWeek[]{}));
 
@@ -198,7 +198,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll Random random) {
+	void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -212,7 +212,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll Random random) {
+	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll JqwikRandom random) {
 
 		Assume.that(startHour <= endHour);
 
@@ -227,7 +227,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll Random random) {
+	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll JqwikRandom random) {
 
 		Assume.that(startMinute <= endMinute);
 
@@ -242,7 +242,7 @@ public class InstantMethodsTests {
 	}
 
 	@Property
-	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll Random random) {
+	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll JqwikRandom random) {
 
 		Assume.that(startSecond <= endSecond);
 

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/instant/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/instant/ShrinkingTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		InstantArbitrary instants = DateTimes.instants();
 		Instant value = falsifyThenShrink(instants, random);
 		assertThat(value).isEqualTo(LocalDateTime.of(1900, JANUARY, 1, 0, 0, 0).toInstant(ZoneOffset.UTC));

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/ShrinkingTests.java
@@ -16,14 +16,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		LocalDateTimeArbitrary dateTimes = DateTimes.dateTimes();
 		LocalDateTime value = falsifyThenShrink(dateTimes, random);
 		assertThat(value).isEqualTo(LocalDateTime.of(1900, JANUARY, 1, 0, 0, 0));
 	}
 
 	@Property(tries = 40)
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		LocalDateTimeArbitrary dateTimes = DateTimes.dateTimes();
 		TestingFalsifier<LocalDateTime> falsifier = dateTime -> dateTime.isBefore(LocalDateTime.of(2013, MAY, 25, 13, 12, 55));
 		LocalDateTime value = falsifyThenShrink(dateTimes, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/SimpleArbitrariesTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/SimpleArbitrariesTests.java
@@ -31,7 +31,7 @@ public class SimpleArbitrariesTests {
 		@ForAll LocalDate date,
 		@ForAll @IntRange(min = 50, max = 59) int secondEnd,
 		@ForAll @IntRange(max = 10) int secondStart,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(!date.isEqual(LocalDate.MAX));
@@ -52,7 +52,7 @@ public class SimpleArbitrariesTests {
 		@ForAll LocalDate date,
 		@ForAll @IntRange(min = 999_999_800, max = 999_999_999) int nanoEnd,
 		@ForAll @IntRange(max = 200) int nanoStart,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(!date.isEqual(LocalDate.MAX));

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/dateTimeMethods/DateTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/dateTimeMethods/DateTests.java
@@ -24,7 +24,7 @@ public class DateTests {
 	class DateBetweenMethod {
 
 		@Property
-		void between(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll Random random) {
+		void between(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll JqwikRandom random) {
 
 			Assume.that(!min.isAfter(max));
 
@@ -39,7 +39,7 @@ public class DateTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll LocalDate same, @ForAll Random random) {
+		void betweenSame(@ForAll LocalDate same, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().dateBetween(same, same);
 
@@ -56,7 +56,7 @@ public class DateTests {
 			@ForAll LocalDate maxDate,
 			@ForAll("dateTimes") LocalDateTime min,
 			@ForAll("dateTimes") LocalDateTime max,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(!minDate.isAfter(maxDate));
@@ -80,7 +80,7 @@ public class DateTests {
 	class YearMethods {
 
 		@Property
-		void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll Random random) {
+		void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll JqwikRandom random) {
 
 			Assume.that(min <= max);
 
@@ -95,7 +95,7 @@ public class DateTests {
 		}
 
 		@Property
-		void yearBetweenSame(@ForAll("years") int year, @ForAll Random random) {
+		void yearBetweenSame(@ForAll("years") int year, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().yearBetween(year, year);
 
@@ -107,7 +107,7 @@ public class DateTests {
 		}
 
 		@Property
-		void yearBetweenMinAfterMax(@ForAll("years") int min, @ForAll("years") int max, @ForAll Random random) {
+		void yearBetweenMinAfterMax(@ForAll("years") int min, @ForAll("years") int max, @ForAll JqwikRandom random) {
 
 			Assume.that(min > max);
 
@@ -132,7 +132,7 @@ public class DateTests {
 	class MonthMethods {
 
 		@Property
-		void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll Random random) {
+		void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll JqwikRandom random) {
 
 			Assume.that(min <= max);
 
@@ -147,7 +147,7 @@ public class DateTests {
 		}
 
 		@Property
-		void monthBetweenSame(@ForAll("months") int month, @ForAll Random random) {
+		void monthBetweenSame(@ForAll("months") int month, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().monthBetween(month, month);
 
@@ -159,7 +159,7 @@ public class DateTests {
 		}
 
 		@Property
-		void monthBetweenMinAfterMax(@ForAll("months") int min, @ForAll("months") int max, @ForAll Random random) {
+		void monthBetweenMinAfterMax(@ForAll("months") int min, @ForAll("months") int max, @ForAll JqwikRandom random) {
 
 			Assume.that(min > max);
 
@@ -174,7 +174,7 @@ public class DateTests {
 		}
 
 		@Property
-		void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+		void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().onlyMonths(months.toArray(new Month[]{}));
 
@@ -199,7 +199,7 @@ public class DateTests {
 		void dayOfMonthBetween(
 			@ForAll("dayOfMonths") int min,
 			@ForAll("dayOfMonths") int max,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(min <= max);
@@ -218,7 +218,7 @@ public class DateTests {
 		void dayOfMonthBetweenStartAfterEnd(
 			@ForAll("dayOfMonths") int min,
 			@ForAll("dayOfMonths") int max,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(min > max);
@@ -234,7 +234,7 @@ public class DateTests {
 		}
 
 		@Property
-		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll Random random) {
+		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().dayOfMonthBetween(dayOfMonth, dayOfMonth);
 
@@ -256,7 +256,7 @@ public class DateTests {
 	class OnlyDaysOfWeekMethods {
 
 		@Property
-		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll Random random) {
+		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().onlyDaysOfWeek(dayOfWeeks.toArray(new DayOfWeek[]{}));
 

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/dateTimeMethods/DateTimeTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/dateTimeMethods/DateTimeTests.java
@@ -18,7 +18,7 @@ public class DateTimeTests {
 	}
 
 	@Property
-	void atTheEarliest(@ForAll("dateTimes") LocalDateTime min, @ForAll Random random) {
+	void atTheEarliest(@ForAll("dateTimes") LocalDateTime min, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().atTheEarliest(min);
 
@@ -33,7 +33,7 @@ public class DateTimeTests {
 	void atTheEarliestAtTheLatestMinAfterMax(
 		@ForAll("dateTimes") LocalDateTime min,
 		@ForAll("dateTimes") LocalDateTime max,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(min.isAfter(max));
@@ -49,7 +49,7 @@ public class DateTimeTests {
 	}
 
 	@Property
-	void atTheLatest(@ForAll("dateTimes") LocalDateTime max, @ForAll Random random) {
+	void atTheLatest(@ForAll("dateTimes") LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().atTheLatest(max);
 
@@ -64,7 +64,7 @@ public class DateTimeTests {
 	void atTheLatestAtTheEarliestMinAfterMax(
 		@ForAll("dateTimes") LocalDateTime min,
 		@ForAll("dateTimes") LocalDateTime max,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(min.isAfter(max));
@@ -80,7 +80,7 @@ public class DateTimeTests {
 	}
 
 	@Property
-	void between(@ForAll("dateTimes") LocalDateTime min, @ForAll("dateTimes") LocalDateTime max, @ForAll Random random) {
+	void between(@ForAll("dateTimes") LocalDateTime min, @ForAll("dateTimes") LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -95,7 +95,7 @@ public class DateTimeTests {
 	}
 
 	@Property
-	void betweenMinAfterMax(@ForAll("dateTimes") LocalDateTime min, @ForAll("dateTimes") LocalDateTime max, @ForAll Random random) {
+	void betweenMinAfterMax(@ForAll("dateTimes") LocalDateTime min, @ForAll("dateTimes") LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(min.isAfter(max));
 
@@ -110,7 +110,7 @@ public class DateTimeTests {
 	}
 
 	@Property
-	void betweenSame(@ForAll("dateTimes") LocalDateTime same, @ForAll Random random) {
+	void betweenSame(@ForAll("dateTimes") LocalDateTime same, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().between(same, same);
 

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/dateTimeMethods/TimeTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/localDateTime/dateTimeMethods/TimeTests.java
@@ -68,7 +68,7 @@ public class TimeTests {
 	class TimeBetweenMethods {
 
 		@Property
-		void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll Random random) {
+		void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll JqwikRandom random) {
 
 			Assume.that(!min.isAfter(max));
 
@@ -82,7 +82,7 @@ public class TimeTests {
 		}
 
 		@Property
-		void timeBetweenMaxBeforeMin(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll Random random) {
+		void timeBetweenMaxBeforeMin(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll JqwikRandom random) {
 
 			Assume.that(min.isAfter(max));
 
@@ -96,7 +96,7 @@ public class TimeTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll LocalTime same, @ForAll Random random) {
+		void betweenSame(@ForAll LocalTime same, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().timeBetween(same, same);
 
@@ -113,7 +113,7 @@ public class TimeTests {
 	class HourMethods {
 
 		@Property
-		void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll Random random) {
+		void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll JqwikRandom random) {
 
 			Assume.that(startHour <= endHour);
 
@@ -128,7 +128,7 @@ public class TimeTests {
 		}
 
 		@Property
-		void hourBetweenSame(@ForAll("hours") int hour, @ForAll Random random) {
+		void hourBetweenSame(@ForAll("hours") int hour, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().hourBetween(hour, hour);
 
@@ -145,7 +145,7 @@ public class TimeTests {
 	class MinuteMethods {
 
 		@Property
-		void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll Random random) {
+		void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll JqwikRandom random) {
 
 			Assume.that(startMinute <= endMinute);
 
@@ -160,7 +160,7 @@ public class TimeTests {
 		}
 
 		@Property
-		void minuteBetweenSame(@ForAll("minutes") int minute, @ForAll Random random) {
+		void minuteBetweenSame(@ForAll("minutes") int minute, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().minuteBetween(minute, minute);
 
@@ -177,7 +177,7 @@ public class TimeTests {
 	class SecondMethods {
 
 		@Property
-		void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll Random random) {
+		void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll JqwikRandom random) {
 
 			Assume.that(startSecond <= endSecond);
 
@@ -192,7 +192,7 @@ public class TimeTests {
 		}
 
 		@Property
-		void secondBetweenSame(@ForAll("seconds") int second, @ForAll Random random) {
+		void secondBetweenSame(@ForAll("seconds") int second, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDateTime> dateTimes = DateTimes.dateTimes().secondBetween(second, second);
 

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/offsetDateTime/OffsetDateTimeMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/offsetDateTime/OffsetDateTimeMethodsTests.java
@@ -51,7 +51,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void atTheEarliest(@ForAll LocalDateTime min, @ForAll Random random) {
+	void atTheEarliest(@ForAll LocalDateTime min, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetDateTime> dateTimes = DateTimes.offsetDateTimes().atTheEarliest(min);
 
@@ -63,7 +63,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void atTheLatest(@ForAll LocalDateTime max, @ForAll Random random) {
+	void atTheLatest(@ForAll LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetDateTime> dateTimes = DateTimes.offsetDateTimes().atTheLatest(max);
 
@@ -75,7 +75,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void between(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll Random random) {
+	void between(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -90,7 +90,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void betweenMinAfterMax(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll Random random) {
+	void betweenMinAfterMax(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(min.isAfter(max));
 
@@ -105,7 +105,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void dateBetween(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll Random random) {
+	void dateBetween(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -120,7 +120,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll Random random) {
+	void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll JqwikRandom random) {
 
 		Assume.that(min <= max);
 
@@ -135,7 +135,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll Random random) {
+	void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll JqwikRandom random) {
 
 		Assume.that(min <= max);
 
@@ -150,7 +150,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+	void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetDateTime> dateTimes = DateTimes.offsetDateTimes().onlyMonths(months.toArray(new Month[]{}));
 
@@ -165,7 +165,7 @@ public class OffsetDateTimeMethodsTests {
 	void dayOfMonthBetween(
 		@ForAll("dayOfMonths") int min,
 		@ForAll("dayOfMonths") int max,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(min <= max);
@@ -181,7 +181,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll Random random) {
+	void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetDateTime> dateTimes = DateTimes.offsetDateTimes().onlyDaysOfWeek(dayOfWeeks.toArray(new DayOfWeek[]{}));
 
@@ -192,7 +192,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll Random random) {
+	void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -206,7 +206,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll Random random) {
+	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll JqwikRandom random) {
 
 		Assume.that(startHour <= endHour);
 
@@ -221,7 +221,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll Random random) {
+	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll JqwikRandom random) {
 
 		Assume.that(startMinute <= endMinute);
 
@@ -236,7 +236,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll Random random) {
+	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll JqwikRandom random) {
 
 		Assume.that(startSecond <= endSecond);
 
@@ -258,7 +258,7 @@ public class OffsetDateTimeMethodsTests {
 	}
 
 	@Property
-	void offsetBetween(@ForAll ZoneOffset startOffset, @ForAll ZoneOffset endOffset, @ForAll Random random) {
+	void offsetBetween(@ForAll ZoneOffset startOffset, @ForAll ZoneOffset endOffset, @ForAll JqwikRandom random) {
 
 		Assume.that(startOffset.getTotalSeconds() <= endOffset.getTotalSeconds());
 

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/offsetDateTime/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/offsetDateTime/ShrinkingTests.java
@@ -17,14 +17,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		OffsetDateTimeArbitrary dateTimes = DateTimes.offsetDateTimes();
 		OffsetDateTime value = falsifyThenShrink(dateTimes, random);
 		assertThat(value).isEqualTo(OffsetDateTime.of(LocalDateTime.of(1900, JANUARY, 1, 0, 0, 0), ZoneOffset.UTC));
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		OffsetDateTimeArbitrary dateTimes = DateTimes.offsetDateTimes();
 		TestingFalsifier<OffsetDateTime> falsifier =
 			dateTime -> dateTime.isBefore(OffsetDateTime.of(LocalDateTime.of(2013, MAY, 25, 13, 12, 55), ZoneOffset.ofHours(4)));

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/zonedDateTime/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/zonedDateTime/ShrinkingTests.java
@@ -17,14 +17,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		ZonedDateTimeArbitrary dateTimes = DateTimes.zonedDateTimes();
 		ZonedDateTime value = falsifyThenShrink(dateTimes, random);
 		assertThat(value).isEqualTo(ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("Etc/GMT-14")));
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		ZonedDateTimeArbitrary dateTimes = DateTimes.zonedDateTimes();
 		TestingFalsifier<ZonedDateTime> falsifier =
 			dateTime -> dateTime.isBefore(ZonedDateTime.of(LocalDateTime.of(2013, MAY, 25, 13, 12, 55), ZoneId.of("Indian/Reunion")));

--- a/time/src/test/java/net/jqwik/time/api/dateTimes/zonedDateTime/ZonedDateTimeMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dateTimes/zonedDateTime/ZonedDateTimeMethodsTests.java
@@ -51,7 +51,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void atTheEarliest(@ForAll LocalDateTime min, @ForAll Random random) {
+	void atTheEarliest(@ForAll LocalDateTime min, @ForAll JqwikRandom random) {
 
 		Arbitrary<ZonedDateTime> dateTimes = DateTimes.zonedDateTimes().atTheEarliest(min);
 
@@ -63,7 +63,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void atTheLatest(@ForAll LocalDateTime max, @ForAll Random random) {
+	void atTheLatest(@ForAll LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Arbitrary<ZonedDateTime> dateTimes = DateTimes.zonedDateTimes().atTheLatest(max);
 
@@ -75,7 +75,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void between(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll Random random) {
+	void between(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -90,7 +90,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void betweenMinAfterMax(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll Random random) {
+	void betweenMinAfterMax(@ForAll LocalDateTime min, @ForAll LocalDateTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(min.isAfter(max));
 
@@ -105,7 +105,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void dateBetween(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll Random random) {
+	void dateBetween(@ForAll LocalDate min, @ForAll LocalDate max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -120,7 +120,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll Random random) {
+	void yearBetween(@ForAll("years") int min, @ForAll("years") int max, @ForAll JqwikRandom random) {
 
 		Assume.that(min <= max);
 
@@ -135,7 +135,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll Random random) {
+	void monthBetween(@ForAll("months") int min, @ForAll("months") int max, @ForAll JqwikRandom random) {
 
 		Assume.that(min <= max);
 
@@ -150,7 +150,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+	void onlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 		Arbitrary<ZonedDateTime> dateTimes = DateTimes.zonedDateTimes().onlyMonths(months.toArray(new Month[]{}));
 
@@ -165,7 +165,7 @@ public class ZonedDateTimeMethodsTests {
 	void dayOfMonthBetween(
 		@ForAll("dayOfMonths") int min,
 		@ForAll("dayOfMonths") int max,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(min <= max);
@@ -181,7 +181,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll Random random) {
+	void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll JqwikRandom random) {
 
 		Arbitrary<ZonedDateTime> dateTimes = DateTimes.zonedDateTimes().onlyDaysOfWeek(dayOfWeeks.toArray(new DayOfWeek[]{}));
 
@@ -192,7 +192,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll Random random) {
+	void timeBetween(@ForAll LocalTime min, @ForAll LocalTime max, @ForAll JqwikRandom random) {
 
 		Assume.that(!min.isAfter(max));
 
@@ -206,7 +206,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll Random random) {
+	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll JqwikRandom random) {
 
 		Assume.that(startHour <= endHour);
 
@@ -221,7 +221,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll Random random) {
+	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll JqwikRandom random) {
 
 		Assume.that(startMinute <= endMinute);
 
@@ -236,7 +236,7 @@ public class ZonedDateTimeMethodsTests {
 	}
 
 	@Property
-	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll Random random) {
+	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll JqwikRandom random) {
 
 		Assume.that(startSecond <= endSecond);
 

--- a/time/src/test/java/net/jqwik/time/api/dates/calendar/CalendarMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/calendar/CalendarMethodsTests.java
@@ -25,7 +25,7 @@ public class CalendarMethodsTests {
 	class CalendarMethods {
 
 		@Property
-		void atTheEarliest(@ForAll("dates") Calendar startDate, @ForAll Random random) {
+		void atTheEarliest(@ForAll("dates") Calendar startDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().atTheEarliest(startDate);
 
@@ -40,7 +40,7 @@ public class CalendarMethodsTests {
 		void atTheEarliestAtTheLatestMinAfterMax(
 			@ForAll("dates") Calendar startDate,
 			@ForAll("dates") Calendar endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.after(endDate));
@@ -56,7 +56,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void atTheLatest(@ForAll("dates") Calendar endDate, @ForAll Random random) {
+		void atTheLatest(@ForAll("dates") Calendar endDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().atTheLatest(endDate);
 
@@ -71,7 +71,7 @@ public class CalendarMethodsTests {
 		void atTheLatestAtTheEarliestMinAfterMax(
 			@ForAll("dates") Calendar startDate,
 			@ForAll("dates") Calendar endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.after(endDate));
@@ -87,7 +87,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void between(@ForAll("dates") Calendar startDate, @ForAll("dates") Calendar endDate, @ForAll Random random) {
+		void between(@ForAll("dates") Calendar startDate, @ForAll("dates") Calendar endDate, @ForAll JqwikRandom random) {
 
 			Assume.that(!startDate.after(endDate));
 
@@ -104,7 +104,7 @@ public class CalendarMethodsTests {
 		void betweenEndDateAfterStartDate(
 			@ForAll("dates") Calendar startDate,
 			@ForAll("dates") Calendar endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.after(endDate));
@@ -119,7 +119,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll("dates") Calendar sameDate, @ForAll Random random) {
+		void betweenSame(@ForAll("dates") Calendar sameDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().between(sameDate, sameDate);
 
@@ -136,7 +136,7 @@ public class CalendarMethodsTests {
 	class YearMethods {
 
 		@Property
-		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll Random random) {
+		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll JqwikRandom random) {
 
 			Assume.that(startYear <= endYear);
 
@@ -151,7 +151,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void yearBetweenSame(@ForAll("years") int year, @ForAll Random random) {
+		void yearBetweenSame(@ForAll("years") int year, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().yearBetween(year, year);
 
@@ -173,7 +173,7 @@ public class CalendarMethodsTests {
 	class MonthMethods {
 
 		@Property
-		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth <= endMonth);
 
@@ -188,7 +188,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth > endMonth);
 
@@ -203,7 +203,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void monthBetweenSame(@ForAll("months") int month, @ForAll Random random) {
+		void monthBetweenSame(@ForAll("months") int month, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().monthBetween(month, month);
 
@@ -215,7 +215,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().onlyMonths(months.toArray(new Month[]{}));
 
@@ -241,7 +241,7 @@ public class CalendarMethodsTests {
 		void dayOfMonthBetween(
 			@ForAll("dayOfMonths") int startDayOfMonth,
 			@ForAll("dayOfMonths") int endDayOfMonth,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDayOfMonth <= endDayOfMonth);
@@ -257,7 +257,7 @@ public class CalendarMethodsTests {
 		}
 
 		@Property
-		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll Random random) {
+		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().dayOfMonthBetween(dayOfMonth, dayOfMonth);
 
@@ -279,7 +279,7 @@ public class CalendarMethodsTests {
 	class OnlyDaysOfWeekMethods {
 
 		@Property
-		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll Random random) {
+		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll JqwikRandom random) {
 
 			Arbitrary<Calendar> dates = Dates.datesAsCalendar().onlyDaysOfWeek(dayOfWeeks.toArray(new DayOfWeek[]{}));
 

--- a/time/src/test/java/net/jqwik/time/api/dates/calendar/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/calendar/ShrinkingTests.java
@@ -16,7 +16,7 @@ import static net.jqwik.time.api.testingSupport.ForCalendar.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		CalendarArbitrary dates = Dates.datesAsCalendar();
 		Calendar value = falsifyThenShrink(dates, random);
 		assertThat(value.get(Calendar.YEAR)).isEqualTo(1900);
@@ -25,7 +25,7 @@ public class ShrinkingTests {
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		CalendarArbitrary dates = Dates.datesAsCalendar();
 		Calendar calendar = getCalendar(2013, Calendar.MAY, 24);
 		TestingFalsifier<Calendar> falsifier = date -> !date.after(calendar);

--- a/time/src/test/java/net/jqwik/time/api/dates/date/DateMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/date/DateMethodsTests.java
@@ -26,7 +26,7 @@ public class DateMethodsTests {
 	class DateMethods {
 
 		@Property
-		void atTheEarliest(@ForAll("dates") Date startDate, @ForAll Random random) {
+		void atTheEarliest(@ForAll("dates") Date startDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().atTheEarliest(startDate);
 
@@ -41,7 +41,7 @@ public class DateMethodsTests {
 		void atTheEarliestAtTheLatestMinAfterMax(
 			@ForAll("dates") Date startDate,
 			@ForAll("dates") Date endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.after(endDate));
@@ -57,7 +57,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void atTheLatest(@ForAll("dates") Date endDate, @ForAll Random random) {
+		void atTheLatest(@ForAll("dates") Date endDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().atTheLatest(endDate);
 
@@ -72,7 +72,7 @@ public class DateMethodsTests {
 		void atTheLatestAtTheEarliestMinAfterMax(
 			@ForAll("dates") Date startDate,
 			@ForAll("dates") Date endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.after(endDate));
@@ -88,7 +88,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void between(@ForAll("dates") Date startDate, @ForAll("dates") Date endDate, @ForAll Random random) {
+		void between(@ForAll("dates") Date startDate, @ForAll("dates") Date endDate, @ForAll JqwikRandom random) {
 
 			Assume.that(!startDate.after(endDate));
 
@@ -102,7 +102,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void betweenEndDateBeforeStartDate(@ForAll("dates") Date startDate, @ForAll("dates") Date endDate, @ForAll Random random) {
+		void betweenEndDateBeforeStartDate(@ForAll("dates") Date startDate, @ForAll("dates") Date endDate, @ForAll JqwikRandom random) {
 
 			Assume.that(startDate.after(endDate));
 
@@ -116,7 +116,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll("dates") Date sameDate, @ForAll Random random) {
+		void betweenSame(@ForAll("dates") Date sameDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().between(sameDate, sameDate);
 
@@ -133,7 +133,7 @@ public class DateMethodsTests {
 	class YearMethods {
 
 		@Property
-		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll Random random) {
+		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll JqwikRandom random) {
 
 			Assume.that(startYear <= endYear);
 
@@ -148,7 +148,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void yearBetweenSame(@ForAll("years") int year, @ForAll Random random) {
+		void yearBetweenSame(@ForAll("years") int year, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().yearBetween(year, year);
 
@@ -170,7 +170,7 @@ public class DateMethodsTests {
 	class MonthMethods {
 
 		@Property
-		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth <= endMonth);
 
@@ -186,7 +186,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth > endMonth);
 
@@ -205,7 +205,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void monthBetweenSame(@ForAll("months") int month, @ForAll Random random) {
+		void monthBetweenSame(@ForAll("months") int month, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().monthBetween(month, month);
 
@@ -217,7 +217,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().onlyMonths(months.toArray(new Month[]{}));
 
@@ -242,7 +242,7 @@ public class DateMethodsTests {
 		void dayOfMonthBetween(
 			@ForAll("dayOfMonths") int startDayOfMonth,
 			@ForAll("dayOfMonths") int endDayOfMonth,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDayOfMonth <= endDayOfMonth);
@@ -258,7 +258,7 @@ public class DateMethodsTests {
 		}
 
 		@Property
-		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll Random random) {
+		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().dayOfMonthBetween(dayOfMonth, dayOfMonth);
 
@@ -280,7 +280,7 @@ public class DateMethodsTests {
 	class OnlyDaysOfWeekMethods {
 
 		@Property
-		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll Random random) {
+		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll JqwikRandom random) {
 
 			Arbitrary<Date> dates = Dates.datesAsDate().onlyDaysOfWeek(dayOfWeeks.toArray(new DayOfWeek[]{}));
 

--- a/time/src/test/java/net/jqwik/time/api/dates/date/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/date/ShrinkingTests.java
@@ -17,7 +17,7 @@ import static net.jqwik.time.api.testingSupport.ForDate.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		DateArbitrary dates = Dates.datesAsDate();
 		Calendar value = dateToCalendar(falsifyThenShrink(dates, random));
 		assertThat(value.get(Calendar.YEAR)).isEqualTo(1900);
@@ -26,7 +26,7 @@ public class ShrinkingTests {
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		DateArbitrary dates = Dates.datesAsDate();
 		Calendar calendar = getCalendar(2013, Calendar.MAY, 24);
 		TestingFalsifier<Date> falsifier = date -> !dateToCalendar(date).after(calendar);

--- a/time/src/test/java/net/jqwik/time/api/dates/dayOfMonth/ConstraintTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/dayOfMonth/ConstraintTests.java
@@ -33,7 +33,7 @@ public class ConstraintTests {
 	class InvalidUseOfConstraints {
 
 		@Property
-		void dayOfMonthRange(@ForAll @DayOfMonthRange Random random) {
+		void dayOfMonthRange(@ForAll @DayOfMonthRange JqwikRandom random) {
 			assertThat(random).isNotNull();
 		}
 

--- a/time/src/test/java/net/jqwik/time/api/dates/localDate/DateMethodTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/localDate/DateMethodTests.java
@@ -26,7 +26,7 @@ public class DateMethodTests {
 	class DateMethods {
 
 		@Property
-		void atTheEarliest(@ForAll("dates") LocalDate startDate, @ForAll Random random) {
+		void atTheEarliest(@ForAll("dates") LocalDate startDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().atTheEarliest(startDate);
 
@@ -41,7 +41,7 @@ public class DateMethodTests {
 		void atTheEarliestAtTheLatestMinAfterMax(
 			@ForAll("dates") LocalDate startDate,
 			@ForAll("dates") LocalDate endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.isAfter(endDate));
@@ -57,7 +57,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void atTheLatest(@ForAll("dates") LocalDate endDate, @ForAll Random random) {
+		void atTheLatest(@ForAll("dates") LocalDate endDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().atTheLatest(endDate);
 
@@ -72,7 +72,7 @@ public class DateMethodTests {
 		void atTheLatestAtTheEarliestMinAfterMax(
 			@ForAll("dates") LocalDate startDate,
 			@ForAll("dates") LocalDate endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.isAfter(endDate));
@@ -88,7 +88,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void between(@ForAll("dates") LocalDate startDate, @ForAll("dates") LocalDate endDate, @ForAll Random random) {
+		void between(@ForAll("dates") LocalDate startDate, @ForAll("dates") LocalDate endDate, @ForAll JqwikRandom random) {
 
 			Assume.that(!startDate.isAfter(endDate));
 
@@ -105,7 +105,7 @@ public class DateMethodTests {
 		void betweenEndDateBeforeStartDate(
 			@ForAll("dates") LocalDate startDate,
 			@ForAll("dates") LocalDate endDate,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDate.isAfter(endDate));
@@ -120,7 +120,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll("dates") LocalDate sameDate, @ForAll Random random) {
+		void betweenSame(@ForAll("dates") LocalDate sameDate, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().between(sameDate, sameDate);
 
@@ -137,7 +137,7 @@ public class DateMethodTests {
 	class YearMethods {
 
 		@Property
-		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll Random random) {
+		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll JqwikRandom random) {
 
 			Assume.that(startYear <= endYear);
 
@@ -152,7 +152,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void yearBetweenSame(@ForAll("years") int year, @ForAll Random random) {
+		void yearBetweenSame(@ForAll("years") int year, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().yearBetween(year, year);
 
@@ -174,7 +174,7 @@ public class DateMethodTests {
 	class MonthMethods {
 
 		@Property
-		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth <= endMonth);
 
@@ -189,7 +189,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth > endMonth);
 
@@ -204,7 +204,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void monthBetweenSame(@ForAll("months") int month, @ForAll Random random) {
+		void monthBetweenSame(@ForAll("months") int month, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().monthBetween(month, month);
 
@@ -216,7 +216,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().onlyMonths(months.toArray(new Month[]{}));
 
@@ -241,7 +241,7 @@ public class DateMethodTests {
 		void dayOfMonthBetween(
 			@ForAll("dayOfMonths") int startDayOfMonth,
 			@ForAll("dayOfMonths") int endDayOfMonth,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDayOfMonth <= endDayOfMonth);
@@ -260,7 +260,7 @@ public class DateMethodTests {
 		void dayOfMonthBetweenStartAfterEnd(
 			@ForAll("dayOfMonths") int startDayOfMonth,
 			@ForAll("dayOfMonths") int endDayOfMonth,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDayOfMonth > endDayOfMonth);
@@ -276,7 +276,7 @@ public class DateMethodTests {
 		}
 
 		@Property
-		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll Random random) {
+		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().dayOfMonthBetween(dayOfMonth, dayOfMonth);
 
@@ -298,7 +298,7 @@ public class DateMethodTests {
 	class OnlyDaysOfWeekMethods {
 
 		@Property
-		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll Random random) {
+		void onlyDaysOfWeek(@ForAll @Size(min = 1) Set<DayOfWeek> dayOfWeeks, @ForAll JqwikRandom random) {
 
 			Arbitrary<LocalDate> dates = Dates.dates().onlyDaysOfWeek(dayOfWeeks.toArray(new DayOfWeek[]{}));
 
@@ -319,7 +319,7 @@ public class DateMethodTests {
 			@ForAll LocalDate min,
 			@ForAll LocalDate max,
 			@ForAll @IntRange(max = 2) int offset,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 			Assume.that(max.getYear() - min.getYear() >= 8);
 
@@ -346,7 +346,7 @@ public class DateMethodTests {
 			@ForAll MonthDay monthDay,
 			@ForAll @IntRange(max = 7) int yearOffset,
 			@ForAll @IntRange(max = 2) int dayOfMonthOffset,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(

--- a/time/src/test/java/net/jqwik/time/api/dates/localDate/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/localDate/ShrinkingTests.java
@@ -17,14 +17,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		LocalDateArbitrary dates = Dates.dates();
 		LocalDate value = falsifyThenShrink(dates, random);
 		assertThat(value).isEqualTo(LocalDate.of(1900, JANUARY, 1));
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		LocalDateArbitrary dates = Dates.dates();
 		TestingFalsifier<LocalDate> falsifier = date -> date.isBefore(LocalDate.of(2013, MAY, 25));
 		LocalDate value = falsifyThenShrink(dates, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/dates/monthDay/MonthDayMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/monthDay/MonthDayMethodsTests.java
@@ -24,7 +24,7 @@ public class MonthDayMethodsTests {
 	class MonthDayMethods {
 
 		@Property
-		void atTheEarliest(@ForAll("monthDays") MonthDay monthDay, @ForAll Random random) {
+		void atTheEarliest(@ForAll("monthDays") MonthDay monthDay, @ForAll JqwikRandom random) {
 
 			Arbitrary<MonthDay> dates = Dates.monthDays().atTheEarliest(monthDay);
 
@@ -36,7 +36,7 @@ public class MonthDayMethodsTests {
 		}
 
 		@Property
-		void atTheLatest(@ForAll("monthDays") MonthDay monthDay, @ForAll Random random) {
+		void atTheLatest(@ForAll("monthDays") MonthDay monthDay, @ForAll JqwikRandom random) {
 
 			Arbitrary<MonthDay> dates = Dates.monthDays().atTheLatest(monthDay);
 
@@ -48,7 +48,7 @@ public class MonthDayMethodsTests {
 		}
 
 		@Property
-		void between(@ForAll("monthDays") MonthDay startMonthDay, @ForAll("monthDays") MonthDay endMonthDay, @ForAll Random random) {
+		void between(@ForAll("monthDays") MonthDay startMonthDay, @ForAll("monthDays") MonthDay endMonthDay, @ForAll JqwikRandom random) {
 
 			Assume.that(!startMonthDay.isAfter(endMonthDay));
 
@@ -62,7 +62,7 @@ public class MonthDayMethodsTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll("monthDays") MonthDay monthDay, @ForAll Random random) {
+		void betweenSame(@ForAll("monthDays") MonthDay monthDay, @ForAll JqwikRandom random) {
 
 			Arbitrary<MonthDay> dates = Dates.monthDays().between(monthDay, monthDay);
 
@@ -79,7 +79,7 @@ public class MonthDayMethodsTests {
 	class MonthMethods {
 
 		@Property
-		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth <= endMonth);
 
@@ -94,7 +94,7 @@ public class MonthDayMethodsTests {
 		}
 
 		@Property
-		void monthBetweenSame(@ForAll("months") int month, @ForAll Random random) {
+		void monthBetweenSame(@ForAll("months") int month, @ForAll JqwikRandom random) {
 
 			Arbitrary<MonthDay> dates = Dates.monthDays().monthBetween(month, month);
 
@@ -106,7 +106,7 @@ public class MonthDayMethodsTests {
 		}
 
 		@Property
-		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 			Arbitrary<MonthDay> dates = Dates.monthDays().onlyMonths(months.toArray(new Month[]{}));
 
@@ -131,7 +131,7 @@ public class MonthDayMethodsTests {
 		void dayOfMonthBetween(
 			@ForAll("dayOfMonths") int startDayOfMonth,
 			@ForAll("dayOfMonths") int endDayOfMonth,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(startDayOfMonth <= endDayOfMonth);
@@ -147,7 +147,7 @@ public class MonthDayMethodsTests {
 		}
 
 		@Property
-		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll Random random) {
+		void dayOfMonthBetweenSame(@ForAll("dayOfMonths") int dayOfMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<MonthDay> dates = Dates.monthDays().dayOfMonthBetween(dayOfMonth, dayOfMonth);
 

--- a/time/src/test/java/net/jqwik/time/api/dates/monthDay/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/monthDay/ShrinkingTests.java
@@ -15,14 +15,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		MonthDayArbitrary monthDays = Dates.monthDays();
 		MonthDay value = falsifyThenShrink(monthDays, random);
 		assertThat(value).isEqualTo(MonthDay.of(Month.JANUARY, 1));
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		MonthDayArbitrary monthDays = Dates.monthDays();
 		TestingFalsifier<MonthDay> falsifier = md -> md.isBefore(MonthDay.of(Month.MAY, 25));
 		MonthDay value = falsifyThenShrink(monthDays, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/dates/period/PeriodMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/period/PeriodMethodsTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 public class PeriodMethodsTests {
 
 	@Property
-	void between(@ForAll int start, @ForAll int end, @ForAll Random random) {
+	void between(@ForAll int start, @ForAll int end, @ForAll JqwikRandom random) {
 		Assume.that(start <= end);
 
 		Arbitrary<Period> periods = Dates.periods().between(Period.ofYears(start), Period.ofYears(end));
@@ -26,7 +26,7 @@ public class PeriodMethodsTests {
 	}
 
 	@Property
-	void betweenStartPeriodAfterEndPeriod(@ForAll int start, @ForAll int end, @ForAll Random random) {
+	void betweenStartPeriodAfterEndPeriod(@ForAll int start, @ForAll int end, @ForAll JqwikRandom random) {
 		Assume.that(start > end);
 
 		Arbitrary<Period> periods = Dates.periods().between(Period.ofYears(start), Period.ofYears(end));
@@ -47,7 +47,7 @@ public class PeriodMethodsTests {
 		@ForAll @IntRange(min = 0, max = Integer.MAX_VALUE) int year,
 		@ForAll @IntRange(min = 0, max = 11) int month,
 		@ForAll @IntRange(min = 0, max = 30) int day,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Period minMax = Period.of(year, month, day);

--- a/time/src/test/java/net/jqwik/time/api/dates/period/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/period/ShrinkingTests.java
@@ -15,14 +15,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		PeriodArbitrary periods = Dates.periods();
 		Period value = falsifyThenShrink(periods, random);
 		assertThat(value).isEqualTo(Period.of(0, 0, 0));
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		PeriodArbitrary periods = Dates.periods();
 		TestingFalsifier<Period> falsifier = period -> comparePeriodsWithMax30DaysAnd11Months(period, Period.of(200, 3, 5)) < 0;
 		Period value = falsifyThenShrink(periods, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/dates/year/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/year/ShrinkingTests.java
@@ -16,14 +16,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		YearArbitrary years = Dates.years();
 		Year value = falsifyThenShrink(years, random);
 		assertThat(value).isEqualTo(Year.of(1900));
 	}
 
 	@Property
-	void shrinksToSmallestFailingPositiveValue(@ForAll Random random) {
+	void shrinksToSmallestFailingPositiveValue(@ForAll JqwikRandom random) {
 		YearArbitrary years = Dates.years();
 		TestingFalsifier<Year> falsifier = year -> year.getValue() < 1942;
 		Year value = falsifyThenShrink(years, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/dates/year/YearMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/year/YearMethodsTests.java
@@ -18,7 +18,7 @@ public class YearMethodsTests {
 	}
 
 	@Property
-	void between(@ForAll("years") Year startYear, @ForAll("years") Year endYear, @ForAll Random random) {
+	void between(@ForAll("years") Year startYear, @ForAll("years") Year endYear, @ForAll JqwikRandom random) {
 
 		Assume.that(startYear.compareTo(endYear) <= 0);
 
@@ -33,7 +33,7 @@ public class YearMethodsTests {
 	}
 
 	@Property
-	void betweenSame(@ForAll("years") Year year, @ForAll Random random) {
+	void betweenSame(@ForAll("years") Year year, @ForAll JqwikRandom random) {
 
 		Arbitrary<Year> years = Dates.years().between(year, year);
 

--- a/time/src/test/java/net/jqwik/time/api/dates/yearMonth/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/yearMonth/ShrinkingTests.java
@@ -15,14 +15,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		YearMonthArbitrary yearMonths = Dates.yearMonths();
 		YearMonth value = falsifyThenShrink(yearMonths, random);
 		assertThat(value).isEqualTo(YearMonth.of(1900, Month.JANUARY));
 	}
 
 	@Property
-	void shrinksToSmallestFailingPositiveValue(@ForAll Random random) {
+	void shrinksToSmallestFailingPositiveValue(@ForAll JqwikRandom random) {
 		YearMonthArbitrary yearMonths = Dates.yearMonths();
 		TestingFalsifier<YearMonth> falsifier = ym -> ym.isBefore(YearMonth.of(2013, Month.MAY));
 		YearMonth value = falsifyThenShrink(yearMonths, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/dates/yearMonth/YearMonthMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/dates/yearMonth/YearMonthMethodsTests.java
@@ -24,7 +24,7 @@ public class YearMonthMethodsTests {
 	class YearMonthMethods {
 
 		@Property
-		void atTheEarliest(@ForAll("yearMonths") YearMonth yearMonth, @ForAll Random random) {
+		void atTheEarliest(@ForAll("yearMonths") YearMonth yearMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<YearMonth> yearMonths = Dates.yearMonths().atTheEarliest(yearMonth);
 
@@ -39,7 +39,7 @@ public class YearMonthMethodsTests {
 		void atTheEarliestAtTheLatestMinAfterMax(
 			@ForAll("yearMonths") YearMonth min,
 			@ForAll("yearMonths") YearMonth max,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(min.isAfter(max));
@@ -55,7 +55,7 @@ public class YearMonthMethodsTests {
 		}
 
 		@Property
-		void atTheLatest(@ForAll("yearMonths") YearMonth yearMonth, @ForAll Random random) {
+		void atTheLatest(@ForAll("yearMonths") YearMonth yearMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<YearMonth> yearMonths = Dates.yearMonths().atTheLatest(yearMonth);
 
@@ -70,7 +70,7 @@ public class YearMonthMethodsTests {
 		void atTheLatestAtTheEarliestMinAfterMax(
 			@ForAll("yearMonths") YearMonth min,
 			@ForAll("yearMonths") YearMonth max,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(min.isAfter(max));
@@ -89,7 +89,7 @@ public class YearMonthMethodsTests {
 		void between(
 			@ForAll("yearMonths") YearMonth startYearMonth,
 			@ForAll("yearMonths") YearMonth endYearMonth,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(!startYearMonth.isAfter(endYearMonth));
@@ -104,7 +104,7 @@ public class YearMonthMethodsTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll("yearMonths") YearMonth yearMonth, @ForAll Random random) {
+		void betweenSame(@ForAll("yearMonths") YearMonth yearMonth, @ForAll JqwikRandom random) {
 
 			Arbitrary<YearMonth> yearMonths = Dates.yearMonths().between(yearMonth, yearMonth);
 
@@ -121,7 +121,7 @@ public class YearMonthMethodsTests {
 	class YearMethods {
 
 		@Property
-		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll Random random) {
+		void yearBetween(@ForAll("years") int startYear, @ForAll("years") int endYear, @ForAll JqwikRandom random) {
 
 			Assume.that(startYear <= endYear);
 
@@ -136,7 +136,7 @@ public class YearMonthMethodsTests {
 		}
 
 		@Property
-		void yearBetweenSame(@ForAll("years") int year, @ForAll Random random) {
+		void yearBetweenSame(@ForAll("years") int year, @ForAll JqwikRandom random) {
 
 			Assume.that(year != 0);
 
@@ -160,7 +160,7 @@ public class YearMonthMethodsTests {
 	class MonthMethods {
 
 		@Property
-		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetween(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth <= endMonth);
 
@@ -175,7 +175,7 @@ public class YearMonthMethodsTests {
 		}
 
 		@Property
-		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll Random random) {
+		void monthBetweenMinAfterMax(@ForAll("months") int startMonth, @ForAll("months") int endMonth, @ForAll JqwikRandom random) {
 
 			Assume.that(startMonth > endMonth);
 
@@ -190,7 +190,7 @@ public class YearMonthMethodsTests {
 		}
 
 		@Property
-		void monthBetweenSame(@ForAll("months") int month, @ForAll Random random) {
+		void monthBetweenSame(@ForAll("months") int month, @ForAll JqwikRandom random) {
 
 			Arbitrary<YearMonth> yearMonths = Dates.yearMonths().monthBetween(month, month);
 
@@ -202,7 +202,7 @@ public class YearMonthMethodsTests {
 		}
 
 		@Property
-		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll Random random) {
+		void monthOnlyMonths(@ForAll @Size(min = 1) Set<Month> months, @ForAll JqwikRandom random) {
 
 			Arbitrary<YearMonth> yearMonths = Dates.yearMonths().onlyMonths(months.toArray(new Month[]{}));
 

--- a/time/src/test/java/net/jqwik/time/api/times/duration/DurationMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/duration/DurationMethodsTests.java
@@ -54,7 +54,7 @@ public class DurationMethodsTests {
 	class DurationMethods {
 
 		@Property
-		void between(@ForAll("durations") Duration start, @ForAll("durations") Duration end, @ForAll Random random) {
+		void between(@ForAll("durations") Duration start, @ForAll("durations") Duration end, @ForAll JqwikRandom random) {
 
 			Assume.that(start.compareTo(end) <= 0);
 
@@ -71,7 +71,7 @@ public class DurationMethodsTests {
 		void betweenEndDurationAfterStartDuration(
 			@ForAll("durations") Duration start,
 			@ForAll("durations") Duration end,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(start.compareTo(end) > 0);
@@ -86,7 +86,7 @@ public class DurationMethodsTests {
 		}
 
 		@Property
-		void betweenSame(@ForAll("durations") Duration durationSame, @ForAll Random random) {
+		void betweenSame(@ForAll("durations") Duration durationSame, @ForAll JqwikRandom random) {
 
 			Arbitrary<Duration> durations = Times.durations().between(durationSame, durationSame);
 

--- a/time/src/test/java/net/jqwik/time/api/times/duration/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/duration/ShrinkingTests.java
@@ -15,14 +15,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		DurationArbitrary durations = Times.durations();
 		Duration value = falsifyThenShrink(durations, random);
 		assertThat(value).isEqualTo(Duration.ofSeconds(0, 0));
 	}
 
 	@Property(tries = 40)
-	void shrinksToSmallestFailingPositiveValue(@ForAll Random random) {
+	void shrinksToSmallestFailingPositiveValue(@ForAll JqwikRandom random) {
 		DurationArbitrary durations = Times.durations();
 		TestingFalsifier<Duration> falsifier = duration -> duration.compareTo(Duration.ofSeconds(999_392_192, 709_938_291)) < 0;
 		Duration value = falsifyThenShrink(durations, random, falsifier);
@@ -30,7 +30,7 @@ public class ShrinkingTests {
 	}
 
 	@Property(tries = 10)
-	void shrinksToSmallestFailingNegativeValue(@ForAll Random random) {
+	void shrinksToSmallestFailingNegativeValue(@ForAll JqwikRandom random) {
 		DurationArbitrary durations = Times.durations();
 		TestingFalsifier<Duration> falsifier = duration -> duration.compareTo(Duration.ofSeconds(-999_392_192, 709_938_291)) > 0;
 		Duration value = falsifyThenShrink(durations, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/times/duration/SimpleArbitrariesTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/duration/SimpleArbitrariesTests.java
@@ -34,7 +34,7 @@ public class SimpleArbitrariesTests {
 			@ForAll("worstCase") Duration duration,
 			@ForAll @IntRange(min = 999_999_800, max = 999_999_999) int nanosStart,
 			@ForAll @IntRange(min = 0, max = 200) int nanosEnd,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Duration start = duration.withNanos(nanosStart);
@@ -54,7 +54,7 @@ public class SimpleArbitrariesTests {
 			@ForAll("worstCase") Duration duration,
 			@ForAll @IntRange(min = 999_999_800, max = 999_999_999) int nanosStart,
 			@ForAll @IntRange(min = 0, max = 200) int nanosEnd,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Duration start = duration.withNanos(nanosStart);
@@ -74,7 +74,7 @@ public class SimpleArbitrariesTests {
 			@ForAll("worstCaseNegative") Duration duration,
 			@ForAll @IntRange(min = 999_999_800, max = 999_999_999) int nanosEnd,
 			@ForAll @IntRange(min = 0, max = 200) int nanosStart,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Duration start = duration.withNanos(nanosEnd);
@@ -94,7 +94,7 @@ public class SimpleArbitrariesTests {
 			@ForAll("worstCaseNegative") Duration duration,
 			@ForAll @IntRange(min = 999_999_800, max = 999_999_999) int nanosEnd,
 			@ForAll @IntRange(min = 0, max = 200) int nanosStart,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Duration start = duration.withNanos(nanosEnd);
@@ -113,7 +113,7 @@ public class SimpleArbitrariesTests {
 		void positiveOneSecondDifferenceNanosLow(
 			@ForAll("worstCase") Duration start,
 			@ForAll @IntRange(min = 0, max = 200) int nanosAdd,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(start.getNano() < 1_000_000_000 - nanosAdd);
@@ -133,7 +133,7 @@ public class SimpleArbitrariesTests {
 		void positiveTwoSecondDifferenceNanosLow(
 			@ForAll("worstCase") Duration start,
 			@ForAll @IntRange(min = 0, max = 200) int nanosAdd,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(start.getNano() < 1_000_000_000 - nanosAdd);
@@ -153,7 +153,7 @@ public class SimpleArbitrariesTests {
 		void negativeOneSecondDifferenceNanosLow(
 			@ForAll("worstCaseNegative") Duration start,
 			@ForAll @IntRange(min = 0, max = 200) int nanosSubtract,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(start.getNano() > nanosSubtract);
@@ -173,7 +173,7 @@ public class SimpleArbitrariesTests {
 		void negativeTwoSecondsDifferenceNanosLow(
 			@ForAll("worstCaseNegative") Duration start,
 			@ForAll @IntRange(min = 0, max = 200) int nanosSubtract,
-			@ForAll Random random
+			@ForAll JqwikRandom random
 		) {
 
 			Assume.that(start.getNano() > nanosSubtract);
@@ -190,7 +190,7 @@ public class SimpleArbitrariesTests {
 		}
 
 		@Property
-		void aroundZero(@ForAll Random random) {
+		void aroundZero(@ForAll JqwikRandom random) {
 
 			Duration start = Duration.ofSeconds(0, -101);
 			Duration end = Duration.ofSeconds(0, 100);

--- a/time/src/test/java/net/jqwik/time/api/times/localTime/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/localTime/ShrinkingTests.java
@@ -17,14 +17,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		LocalTimeArbitrary times = Times.times();
 		LocalTime value = falsifyThenShrink(times, random);
 		assertThat(value).isEqualTo(LocalTime.of(0, 0, 0, 0));
 	}
 
 	@Property
-	void shrinksToSmallestFailingValue(@ForAll Random random) {
+	void shrinksToSmallestFailingValue(@ForAll JqwikRandom random) {
 		LocalTimeArbitrary times = Times.times().ofPrecision(SECONDS);
 		TestingFalsifier<LocalTime> falsifier = time -> time.isBefore(LocalTime.of(9, 13, 42, 143_921_111));
 		LocalTime value = falsifyThenShrink(times, random, falsifier);

--- a/time/src/test/java/net/jqwik/time/api/times/localTime/constraint/InvalidUseOfConstraintsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/localTime/constraint/InvalidUseOfConstraintsTests.java
@@ -21,7 +21,7 @@ public class InvalidUseOfConstraintsTests {
 	}
 
 	@Property
-	void minuteRange(@ForAll @MinuteRange(min = 11, max = 13) Random random) {
+	void minuteRange(@ForAll @MinuteRange(min = 11, max = 13) JqwikRandom random) {
 		assertThat(random).isNotNull();
 	}
 

--- a/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/HourTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/HourTests.java
@@ -19,7 +19,7 @@ public class HourTests {
 	}
 
 	@Property
-	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll Random random) {
+	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll JqwikRandom random) {
 
 		Assume.that(startHour <= endHour);
 
@@ -34,7 +34,7 @@ public class HourTests {
 	}
 
 	@Property
-	void hourBetweenSame(@ForAll("hours") int hour, @ForAll Random random) {
+	void hourBetweenSame(@ForAll("hours") int hour, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalTime> times = Times.times().hourBetween(hour, hour);
 

--- a/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/MinuteTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/MinuteTests.java
@@ -19,7 +19,7 @@ public class MinuteTests {
 	}
 
 	@Property
-	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll Random random) {
+	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll JqwikRandom random) {
 
 		Assume.that(startMinute <= endMinute);
 
@@ -34,7 +34,7 @@ public class MinuteTests {
 	}
 
 	@Property
-	void minuteBetweenSame(@ForAll("minutes") int minute, @ForAll Random random) {
+	void minuteBetweenSame(@ForAll("minutes") int minute, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalTime> times = Times.times().minuteBetween(minute, minute);
 

--- a/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/SecondTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/SecondTests.java
@@ -19,7 +19,7 @@ public class SecondTests {
 	}
 
 	@Property
-	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll Random random) {
+	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll JqwikRandom random) {
 
 		Assume.that(startSecond <= endSecond);
 
@@ -34,7 +34,7 @@ public class SecondTests {
 	}
 
 	@Property
-	void secondBetweenSame(@ForAll("seconds") int second, @ForAll Random random) {
+	void secondBetweenSame(@ForAll("seconds") int second, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalTime> times = Times.times().secondBetween(second, second);
 

--- a/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/TimeTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/localTime/timeMethods/TimeTests.java
@@ -19,7 +19,7 @@ public class TimeTests {
 	}
 
 	@Property
-	void atTheEarliest(@ForAll("times") LocalTime startTime, @ForAll Random random) {
+	void atTheEarliest(@ForAll("times") LocalTime startTime, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalTime> times = Times.times().atTheEarliest(startTime);
 
@@ -34,7 +34,7 @@ public class TimeTests {
 	void atTheEarliestAtTheLatestMinAfterMax(
 		@ForAll("times") LocalTime startTime,
 		@ForAll("times") LocalTime endTime,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(startTime.isAfter(endTime));
@@ -50,7 +50,7 @@ public class TimeTests {
 	}
 
 	@Property
-	void atTheLatest(@ForAll("times") LocalTime endTime, @ForAll Random random) {
+	void atTheLatest(@ForAll("times") LocalTime endTime, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalTime> times = Times.times().atTheLatest(endTime);
 
@@ -65,7 +65,7 @@ public class TimeTests {
 	void atTheLatestAtTheEarliestMinAfterMax(
 		@ForAll("times") LocalTime startTime,
 		@ForAll("times") LocalTime endTime,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(startTime.isAfter(endTime));
@@ -81,7 +81,7 @@ public class TimeTests {
 	}
 
 	@Property
-	void between(@ForAll("times") LocalTime startTime, @ForAll("times") LocalTime endTime, @ForAll Random random) {
+	void between(@ForAll("times") LocalTime startTime, @ForAll("times") LocalTime endTime, @ForAll JqwikRandom random) {
 
 		Assume.that(!startTime.isAfter(endTime));
 
@@ -98,7 +98,7 @@ public class TimeTests {
 	void betweenEndTimeBeforeStartTime(
 		@ForAll("times") LocalTime startTime,
 		@ForAll("times") LocalTime endTime,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(startTime.isAfter(endTime));
@@ -113,7 +113,7 @@ public class TimeTests {
 	}
 
 	@Property
-	void betweenSame(@ForAll("times") LocalTime sameTime, @ForAll Random random) {
+	void betweenSame(@ForAll("times") LocalTime sameTime, @ForAll JqwikRandom random) {
 
 		Arbitrary<LocalTime> times = Times.times().between(sameTime, sameTime);
 

--- a/time/src/test/java/net/jqwik/time/api/times/offsetTime/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/offsetTime/ShrinkingTests.java
@@ -15,7 +15,7 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		OffsetTimeArbitrary times = Times.offsetTimes();
 		OffsetTime value = falsifyThenShrink(times, random);
 		assertThat(value).isEqualTo(OffsetTime.of(LocalTime.of(0, 0, 0), ZoneOffset.of("Z")));

--- a/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/HourTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/HourTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 public class HourTests {
 
 	@Property
-	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll Random random) {
+	void hourBetween(@ForAll("hours") int startHour, @ForAll("hours") int endHour, @ForAll JqwikRandom random) {
 
 		Assume.that(startHour <= endHour);
 
@@ -29,7 +29,7 @@ public class HourTests {
 	}
 
 	@Property
-	void hourBetweenSame(@ForAll("hours") int hour, @ForAll Random random) {
+	void hourBetweenSame(@ForAll("hours") int hour, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetTime> times = Times.offsetTimes().hourBetween(hour, hour);
 

--- a/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/MinuteTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/MinuteTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 public class MinuteTests {
 
 	@Property
-	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll Random random) {
+	void minuteBetween(@ForAll("minutes") int startMinute, @ForAll("minutes") int endMinute, @ForAll JqwikRandom random) {
 
 		Assume.that(startMinute <= endMinute);
 
@@ -29,7 +29,7 @@ public class MinuteTests {
 	}
 
 	@Property
-	void minuteBetweenSame(@ForAll("minutes") int minute, @ForAll Random random) {
+	void minuteBetweenSame(@ForAll("minutes") int minute, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetTime> times = Times.offsetTimes().minuteBetween(minute, minute);
 

--- a/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/OffsetTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/OffsetTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 public class OffsetTests {
 
 	@Property
-	void between(@ForAll ZoneOffset startOffset, @ForAll ZoneOffset endOffset, @ForAll Random random) {
+	void between(@ForAll ZoneOffset startOffset, @ForAll ZoneOffset endOffset, @ForAll JqwikRandom random) {
 
 		Assume.that(startOffset.getTotalSeconds() <= endOffset.getTotalSeconds());
 
@@ -29,7 +29,7 @@ public class OffsetTests {
 	}
 
 	@Property
-	void betweenSame(@ForAll ZoneOffset offset, @ForAll Random random) {
+	void betweenSame(@ForAll ZoneOffset offset, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetTime> times = Times.offsetTimes().offsetBetween(offset, offset);
 

--- a/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/SecondTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/SecondTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 public class SecondTests {
 
 	@Property
-	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll Random random) {
+	void secondBetween(@ForAll("seconds") int startSecond, @ForAll("seconds") int endSecond, @ForAll JqwikRandom random) {
 
 		Assume.that(startSecond <= endSecond);
 
@@ -29,7 +29,7 @@ public class SecondTests {
 	}
 
 	@Property
-	void secondBetweenSame(@ForAll("seconds") int second, @ForAll Random random) {
+	void secondBetweenSame(@ForAll("seconds") int second, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetTime> times = Times.offsetTimes().secondBetween(second, second);
 

--- a/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/TimeTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/offsetTime/timeMethods/TimeTests.java
@@ -14,7 +14,7 @@ import static net.jqwik.testing.TestingSupport.*;
 public class TimeTests {
 
 	@Property
-	void atTheEarliest(@ForAll LocalTime startTime, @ForAll Random random) {
+	void atTheEarliest(@ForAll LocalTime startTime, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetTime> times = Times.offsetTimes().atTheEarliest(startTime);
 
@@ -26,7 +26,7 @@ public class TimeTests {
 	}
 
 	@Property
-	void atTheLatest(@ForAll LocalTime endTime, @ForAll Random random) {
+	void atTheLatest(@ForAll LocalTime endTime, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetTime> times = Times.offsetTimes().atTheLatest(endTime);
 
@@ -38,7 +38,7 @@ public class TimeTests {
 	}
 
 	@Property
-	void between(@ForAll LocalTime startTime, @ForAll LocalTime endTime, @ForAll Random random) {
+	void between(@ForAll LocalTime startTime, @ForAll LocalTime endTime, @ForAll JqwikRandom random) {
 
 		Assume.that(!startTime.isAfter(endTime));
 
@@ -55,7 +55,7 @@ public class TimeTests {
 	void betweenEndTimeBeforeStartTime(
 		@ForAll LocalTime startTime,
 		@ForAll LocalTime endTime,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		Assume.that(startTime.isAfter(endTime));
@@ -70,7 +70,7 @@ public class TimeTests {
 	}
 
 	@Property
-	void betweenSame(@ForAll LocalTime sameTime, @ForAll Random random) {
+	void betweenSame(@ForAll LocalTime sameTime, @ForAll JqwikRandom random) {
 
 		Arbitrary<OffsetTime> times = Times.offsetTimes().between(sameTime, sameTime);
 

--- a/time/src/test/java/net/jqwik/time/api/times/zoneOffset/OffsetMethodsTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/zoneOffset/OffsetMethodsTests.java
@@ -19,7 +19,7 @@ public class OffsetMethodsTests {
 	}
 
 	@Property
-	void between(@ForAll("offsets") ZoneOffset startOffset, @ForAll("offsets") ZoneOffset endOffset, @ForAll Random random) {
+	void between(@ForAll("offsets") ZoneOffset startOffset, @ForAll("offsets") ZoneOffset endOffset, @ForAll JqwikRandom random) {
 
 		Assume.that(startOffset.getTotalSeconds() <= endOffset.getTotalSeconds());
 
@@ -33,7 +33,7 @@ public class OffsetMethodsTests {
 	}
 
 	@Property
-	void betweenSame(@ForAll("offsets") ZoneOffset sameOffset, @ForAll Random random) {
+	void betweenSame(@ForAll("offsets") ZoneOffset sameOffset, @ForAll JqwikRandom random) {
 
 		Arbitrary<ZoneOffset> offsets = Times.zoneOffsets().between(sameOffset, sameOffset);
 
@@ -50,7 +50,7 @@ public class OffsetMethodsTests {
 		@ForAll("times") LocalTime end,
 		@ForAll boolean startValueIsPositive,
 		@ForAll boolean endValueIsPositive,
-		@ForAll Random random
+		@ForAll JqwikRandom random
 	) {
 
 		try {

--- a/time/src/test/java/net/jqwik/time/api/times/zoneOffset/ShrinkingTests.java
+++ b/time/src/test/java/net/jqwik/time/api/times/zoneOffset/ShrinkingTests.java
@@ -15,14 +15,14 @@ import static net.jqwik.testing.ShrinkingSupport.*;
 public class ShrinkingTests {
 
 	@Property
-	void defaultShrinking(@ForAll Random random) {
+	void defaultShrinking(@ForAll JqwikRandom random) {
 		ZoneOffsetArbitrary offsets = Times.zoneOffsets();
 		ZoneOffset value = falsifyThenShrink(offsets, random);
 		assertThat(value).isEqualTo(ZoneOffset.of("Z"));
 	}
 
 	@Property
-	void shrinksToSmallestFailingPositiveValue(@ForAll Random random) {
+	void shrinksToSmallestFailingPositiveValue(@ForAll JqwikRandom random) {
 		ZoneOffsetArbitrary offsets = Times.zoneOffsets();
 		TestingFalsifier<ZoneOffset> falsifier = offset -> offset.getTotalSeconds() < ZoneOffset.ofHoursMinutesSeconds(2, 14, 33)
 																								.getTotalSeconds();
@@ -31,7 +31,7 @@ public class ShrinkingTests {
 	}
 
 	@Property
-	void shrinksToSmallestFailingNegativeValue(@ForAll Random random) {
+	void shrinksToSmallestFailingNegativeValue(@ForAll JqwikRandom random) {
 		ZoneOffsetArbitrary offsets = Times.zoneOffsets();
 		TestingFalsifier<ZoneOffset> falsifier = offset -> offset.getTotalSeconds() > ZoneOffset.ofHoursMinutesSeconds(-2, -14, -33)
 																								.getTotalSeconds();

--- a/web/src/test/java/net/jqwik/web/api/EmailsTests.java
+++ b/web/src/test/java/net/jqwik/web/api/EmailsTests.java
@@ -183,14 +183,14 @@ public class EmailsTests {
 	class ShrinkingTests {
 
 		@Property
-		void defaultShrinking(@ForAll Random random) {
+		void defaultShrinking(@ForAll JqwikRandom random) {
 			EmailArbitrary emails = Web.emails();
 			String value = falsifyThenShrink(emails.generator(1000), random, TestingFalsifier.alwaysFalsify());
 			assertThat(value).isEqualTo("a@a.aa");
 		}
 
 		@Property
-		void domainShrinking(@ForAll Random random) {
+		void domainShrinking(@ForAll JqwikRandom random) {
 			EmailArbitrary emails = Web.emails();
 			Falsifier<String> falsifier = falsifyDomain();
 			String value = falsifyThenShrink(emails.generator(1000), random, falsifier);
@@ -198,7 +198,7 @@ public class EmailsTests {
 		}
 
 		@Property
-		void ipv4Shrinking(@ForAll Random random) {
+		void ipv4Shrinking(@ForAll JqwikRandom random) {
 			EmailArbitrary emails = Web.emails().allowIpv4Host();
 			Falsifier<String> falsifier = falsifyIPv4();
 			String value = falsifyThenShrink(emails.generator(1000), random, falsifier);
@@ -206,7 +206,7 @@ public class EmailsTests {
 		}
 
 		@Property
-		void ipv6Shrinking(@ForAll Random random) {
+		void ipv6Shrinking(@ForAll JqwikRandom random) {
 			Arbitrary<String> emails = Web.emails().allowIpv6Host();
 			Falsifier<String> falsifier = falsifyIPv6();
 			String value = falsifyThenShrink(emails.generator(1000), random, falsifier);

--- a/web/src/test/java/net/jqwik/web/api/WebDomainTests.java
+++ b/web/src/test/java/net/jqwik/web/api/WebDomainTests.java
@@ -58,14 +58,14 @@ class WebDomainTests {
 
 		@Property(tries = 10)
 		@Label("shrink down to a.aa")
-		void shrinkDownToAdotAA(@ForAll Random random) {
+		void shrinkDownToAdotAA(@ForAll JqwikRandom random) {
 			Arbitrary<String> domains = Web.webDomains();
 			String value = falsifyThenShrink(domains.generator(1000), random, TestingFalsifier.alwaysFalsify());
 			assertThat(value).isEqualTo("a.aa");
 		}
 
 		@Property(tries = 10)
-		void shrinkTo4Subdomains(@ForAll Random random) {
+		void shrinkTo4Subdomains(@ForAll JqwikRandom random) {
 			Arbitrary<String> domains = Web.webDomains();
 			Falsifier<String> falsifier = domain -> {
 				long countDots = domain.chars().filter(c -> c == '.').count();


### PR DESCRIPTION
## Overview

See https://github.com/jlink/jqwik/issues/363

This is more like work-in-progress, however, it looks like the changes are not really big.

Basically:
* `long seed` -> `JqwikRandomState seed`
*  `Random` -> `JqwikRandom`
* The seed looks like in base36. It takes 198 chars, it is easy to select by double-clicking. If we add upper-case letters, then it would be 172 chars, which is not a significant improvement, however, we won't be able to reuse Java's standard base36 encode-decode. `seed = 1piidb7t9rfnx31xty9qfxo1jlx1qi9wkegpnxl5w4geilda60j7rbjntetpvuuveabbeejzi02hl4pmwmjaoe61mv8iny98hlgfmgq36fqiw9kdpeocp8qhvj84j56l7g1xhlxlfkr7sne536w2d0rvmksz1ze3gd0y3y3jwfa7q3m3myaj6qi3wwmxdi5mdig2jmy1a3jwb58g4i95aow5h6hodvkom8i9xeuafi4ug009s2maxqyele0gzcz4ykihtvprq7d059n29lpy3hb5qiz29| random seed to reproduce generated values`


There's a possibility to use `net.jqwik.api.Random`, however, I am afraid it would clash with `java.util.Random`.

I'm not sure if it is worth making a distinction between the seed (the one you use to create a random generator), and the state of the generator.

Commons-rng allows to export the state of a random generator to an object, however, it does not provide cross-version compatibility for that state. In other words we can't use saveState/restoreState for `@Property(seed="...")`

At the same time, if we use .split(), .jump() for splitting the generator instead of nextSeed=random.nextLong(), then the only thing we can have is the internal, non-serializable state of the newly split generator.
We can't really infer "the values we should pass as byte[]seed in order to produce the same generator, as we got after the split"

I would try adding both seed (optional) and state (optional, computed from seed if missing) to an opaque interface JqwikRandomState. Then we could both have cross-version seed values and use random.split() in the test engine.

WDYT?

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
