### PR TITLE
Optimize .flatMap(... -> Stream.of(..)) with .map(...) in ShrinkableChainShrinker

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/properties/state/ShrinkableChainShrinker.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/state/ShrinkableChainShrinker.java
@@ -147,10 +147,10 @@ class ShrinkableChainShrinker<T> {
 			int index = i;
 			ShrinkableChainIteration<T> iteration = iterationsRange.get(i);
 			Shrinkable<Transformer<T>> element = iteration.shrinkable;
-			Stream<List<ShrinkableChainIteration<T>>> shrinkElement = element.shrink().flatMap(shrunkElement -> {
+			Stream<List<ShrinkableChainIteration<T>>> shrinkElement = element.shrink().map(shrunkElement -> {
 				List<ShrinkableChainIteration<T>> iterationsCopy = new ArrayList<>(iterationsRange);
 				iterationsCopy.set(index, iteration.withShrinkable(shrunkElement));
-				return Stream.of(iterationsCopy);
+				return iterationsCopy;
 			});
 			shrinkPerElementStreams.add(shrinkElement);
 		}


### PR DESCRIPTION
This is a small optimization that mainly makes code easier to follow, however, it does improve perf from 28 to 26 sec

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).