### PR TITLE
Optimize ShrinkingDistance: reduce long[] allocations when computing distance for collections

### DIFF
--- a/engine/src/test/java/net/jqwik/engine/properties/shrinking/LazyArbitraryShrinkingTests.java
+++ b/engine/src/test/java/net/jqwik/engine/properties/shrinking/LazyArbitraryShrinkingTests.java
@@ -59,7 +59,11 @@ class LazyArbitraryShrinkingTests {
 			});
 		List<Integer> shrunkValue = shrink(falsifiedShrinkable, falsifier, null);
 
-		Assertions.assertThat(shrunkValue.size()).isLessThanOrEqualTo(falsifiedShrinkable.value().size());
+		Assertions.assertThat(shrunkValue.size())
+			.describedAs(
+				"shrunk.value().size() should improve when compared with original falsifiedShrinkable.value().size()." +
+					" falsifiedShrinkable.value(): %s, shrunk.value(): %s", falsifiedShrinkable.value(), shrunkValue)
+				  .isLessThanOrEqualTo(falsifiedShrinkable.value().size());
 		// TODO: Shrinking should be improved so that:
 		// Assertions.assertThat(shrunkValue).isEqualTo(Arrays.asList(1, 1));
 	}


### PR DESCRIPTION
## Overview

`ShrinkingDistance#forCollection` and `combine` are used a lot, and they might easily account for lots of time spent in re-allocating long arrays.

Sample:

<img width="1125" alt="ShrinkingDistance in allocation hotspot" src="https://user-images.githubusercontent.com/213894/207578077-c834b228-b6e2-45a5-89d6-211bc2824881.png">

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
