### PR TITLE
Cache several shrink results for every chain step, so it does not re-access state model state during shrink phase

### DIFF
--- a/engine/src/main/java/net/jqwik/engine/properties/state/ShrinkableChainIteration.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/state/ShrinkableChainIteration.java
@@ -2,16 +2,63 @@ package net.jqwik.engine.properties.state;
 
 import java.util.*;
 import java.util.function.*;
+import java.util.stream.*;
 
 import net.jqwik.api.*;
 import net.jqwik.api.state.*;
 
-import org.jetbrains.annotations.*;
-
 class ShrinkableChainIteration<T> {
+	// Larger values might improve shrink quality, however, they increase the shrink space, so it might increase shrink duration
+	private final static int NUM_SAMPLES_IN_EAGER_CHAIN_SHRINK = Integer.getInteger("jqwik.eagerChainShrinkSamples", 2);
+
+	static class ShrinkableWithEagerValue<T> implements Shrinkable<T> {
+		protected final Shrinkable<T> base;
+		private final ShrinkingDistance distance;
+		final T value;
+
+		ShrinkableWithEagerValue(Shrinkable<T> base) {
+			this.base = base;
+			this.distance = base.distance();
+			this.value = base.value();
+		}
+
+		@Override
+		public T value() {
+			return value;
+		}
+
+		@Override
+		public Stream<Shrinkable<T>> shrink() {
+			return base.shrink();
+		}
+
+		@Override
+		public ShrinkingDistance distance() {
+			return distance;
+		}
+	}
+
+	static class EagerShrinkable<T> extends ShrinkableWithEagerValue<T> {
+		private final List<Shrinkable<T>> shrinkResults;
+
+		EagerShrinkable(Shrinkable<T> base, int numSamples) {
+			super(base);
+			this.shrinkResults =
+				base.shrink()
+					.sorted(Comparator.comparing(Shrinkable::distance))
+					.limit(numSamples)
+					.map(ShrinkableWithEagerValue::new)
+					.collect(Collectors.toList());
+		}
+
+		@Override
+		public Stream<Shrinkable<T>> shrink() {
+			return shrinkResults.stream();
+		}
+	}
+
 	final Shrinkable<Transformer<T>> shrinkable;
 	private final Predicate<T> precondition;
-	private final @Nullable Transformer<T> transformer;
 	final boolean accessState;
 	final boolean changeState;
 
@@ -33,10 +80,17 @@ class ShrinkableChainIteration<T> {
 		this.precondition = precondition;
 		this.accessState = accessState;
 		this.changeState = changeState;
-		this.shrinkable = shrinkable;
-		// Transformer method might access state, so we need to cache the value here
-		// otherwise it might be evaluated with wrong state (e.g. after chain executes)
-		this.transformer = accessState ? shrinkable.value() : null;
+		// When the shrinkable does not access state, we could just use it as is for ".value()", and ".shrink()"
+		// If we get LazyShrinkable here, it means we are in a shrinking phase, so we know ".shrink()" will be called only
+		// in case the subsequent execution fails. So we can just keep LazyShrinkable as is
+		// Otherwise, we need to eagerly evaluate the shrinkables to since the state might change by appyling subsequent transformers,
+		// so we won't be able to access the state anymore.
+		// See https://github.com/jlink/jqwik/issues/428
+		if (!accessState || shrinkable instanceof ShrinkableChainIteration.ShrinkableWithEagerValue) {
+			this.shrinkable = shrinkable;
+		} else {
+			this.shrinkable = new EagerShrinkable<>(shrinkable, NUM_SAMPLES_IN_EAGER_CHAIN_SHRINK);
+		}
 	}
 
 	@Override
@@ -71,6 +125,6 @@ class ShrinkableChainIteration<T> {
 	}
 
 	Transformer<T> transformer() {
-		return transformer == null ? shrinkable.value() : transformer;
+		return shrinkable.value();
 	}
 }


### PR DESCRIPTION
## Overview

See "a" in https://github.com/jlink/jqwik/issues/428#issuecomment-1350497917

a) Sample (and keep) several .shrink() results for each action before the action is executed.
Pro: we would have valid shrink results (the shrink result would strictly correspond to the state)
Cons: it would spend time and memory on keeping .shrink() results even in case the chain succeeds.
Cons: it does not fully fit "try many different shrink types, order them, and start with the most promising ones" since we would be able to keep only a few shrink results for each action.


### Details

The number of cached shrinkables could be configured via `jqwik.eagerChainShrinkSamples` system property. I default it to 2.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
