### PR TITLE
ChooseValueArbitrary::hashCode cached to improve performance

### DIFF
--- a/api/src/main/java/net/jqwik/api/Arbitraries.java
+++ b/api/src/main/java/net/jqwik/api/Arbitraries.java
@@ -3,7 +3,6 @@ package net.jqwik.api;
 import javax.annotation.*;
 import java.util.*;
 import java.util.function.*;
-import java.util.stream.*;
 
 import org.apiguardian.api.*;
 
@@ -148,9 +147,10 @@ public class Arbitraries {
 	 * A generated value will be shrunk towards the start of the collection.
 	 *
 	 * <p>
-	 * Use this method only for immutable values, because changing the value will change
-	 * subsequent generated values as well.
+	 * Use this method only for and immutable collections of immutable values.
+	 * Changing a value will change subsequently generated values as well.
 	 * For mutable values use {@linkplain #ofSuppliers(Collection)} instead.
+	 * Modifying the collection may cause erratic behavior, kittens may die.
 	 *
 	 * @param values The collection of values to choose from
 	 * @param <T>    The type of values to generate
@@ -729,6 +729,8 @@ public class Arbitraries {
 
 	/**
 	 * Create a new arbitrary of element type {@code Set<T>} using the handed in values as elements of the set.
+	 * The array of values is considered to be immutable. Modifications of the array or its content will cause
+	 * erratic behavior, things may halt and catch fire.
 	 *
 	 * @return a new arbitrary instance
 	 */

--- a/api/src/main/java/net/jqwik/api/Arbitraries.java
+++ b/api/src/main/java/net/jqwik/api/Arbitraries.java
@@ -129,9 +129,11 @@ public class Arbitraries {
 	 * A generated value will be shrunk towards the start of the array.
 	 *
 	 * <p>
-	 * Use this method only for immutable values, because changing the value will change
-	 * subsequent generated values as well.
+	 * Use this method only for immutable arrays of immutable values.
+	 * Changing a value will change subsequently generated values as well.
 	 * For mutable values use {@linkplain #ofSuppliers(Supplier[])} instead.
+	 * Modifying the array may cause erratic behavior, things may halt and
+	 * catch fire.
 	 *
 	 * @param values The array of values to choose from
 	 * @param <T>    The type of values to generate
@@ -147,7 +149,7 @@ public class Arbitraries {
 	 * A generated value will be shrunk towards the start of the collection.
 	 *
 	 * <p>
-	 * Use this method only for and immutable collections of immutable values.
+	 * Use this method only for immutable collections of immutable values.
 	 * Changing a value will change subsequently generated values as well.
 	 * For mutable values use {@linkplain #ofSuppliers(Collection)} instead.
 	 * Modifying the collection may cause erratic behavior, kittens may die.
@@ -729,8 +731,6 @@ public class Arbitraries {
 
 	/**
 	 * Create a new arbitrary of element type {@code Set<T>} using the handed in values as elements of the set.
-	 * The array of values is considered to be immutable. Modifications of the array or its content will cause
-	 * erratic behavior, things may halt and catch fire.
 	 *
 	 * @return a new arbitrary instance
 	 */

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/ChooseValueArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/ChooseValueArbitrary.java
@@ -7,6 +7,7 @@ import net.jqwik.engine.properties.arbitraries.randomized.*;
 
 public class ChooseValueArbitrary<T> extends FromGeneratorsArbitrary<T> {
 
+	private final int hashCode;
 	private final List<T> values;
 
 	public ChooseValueArbitrary(List<T> values) {
@@ -15,6 +16,7 @@ public class ChooseValueArbitrary<T> extends FromGeneratorsArbitrary<T> {
 			max -> ExhaustiveGenerators.choose(values, max),
 			maxEdgeCases -> EdgeCasesSupport.choose(values, maxEdgeCases)
 		);
+		hashCode = values.hashCode();
 		this.values = values;
 	}
 
@@ -29,6 +31,6 @@ public class ChooseValueArbitrary<T> extends FromGeneratorsArbitrary<T> {
 
 	@Override
 	public int hashCode() {
-		return values.hashCode();
+		return hashCode;
 	}
 }


### PR DESCRIPTION
## Overview

`Arbitraries.of(List<T>)` is pathologically slow for large lists. Profiling indicates that the culprit is a large number of List::hashCode calls by `ChooseValueArbitrary`.

### Details
This PR is a suggestion of how to reduce `hashCode` calls by caching, which - hopefully - doesn't break anything (fingers crossed). Documentation dramaturgy has been ramped up to clarify proper use of the API calls.

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
