### PR TITLE
test: add IBM Semeru Java distribution to test matrix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,17 +54,19 @@ jobs:
         with:
           script: |
             console.log('The following command might help reproducing CI results, use Java ${{ matrix.java_version }}')
-            console.log('TZ="${{ matrix.tz }}" _JAVA_OPTIONS="${{ matrix.testExtraJvmArgs }}" ./gradlew check ${{ matrix.extraGradleArgs }}')
+            console.log('TZ="${{ matrix.tz }}" _JAVA_OPTIONS="${{ matrix.extraJvmArgs }}" ./gradlew check ${{ matrix.extraGradleArgs }} -PtestExtraJvmArgs="${{ matrix.testExtraJvmArgs }}"')
 
       - uses: burrunan/gradle-cache-action@v1
         # See https://github.com/burrunan/gradle-cache-action
         name: Build and Test
         env:
-          _JAVA_OPTIONS: ${{ matrix.testExtraJvmArgs }}
+          _JAVA_OPTIONS: ${{ matrix.extraJvmArgs }}
         with:
           # It allows different cache contents for different JDKs
           job-id: java${{ matrix.java_version }}
           arguments: check -DshowStandardStreams=true ${{ matrix.extraGradleArgs }}
+          properties: |
+            testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
 
 #      - name: Publish Test Report
 #        uses: scacap/action-surefire-report@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,7 +23,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
-      MATRIX_JOBS: 4
+      MATRIX_JOBS: 15
     steps:
     - uses: actions/checkout@v3
     - id: set-matrix
@@ -36,7 +36,7 @@ jobs:
     needs: matrix_prep
     strategy:
       matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
-      # fail-fast: false
+      fail-fast: false
     env:
       TZ: ${{ matrix.tz }}
     steps:

--- a/.github/workflows/matrix_builder.js
+++ b/.github/workflows/matrix_builder.js
@@ -152,7 +152,13 @@ class MatrixBuilder {
               return title;
             }
             const computeTitle = this.axisByName[axisName].title;
-            return computeTitle ? computeTitle(value) : value;
+            if (computeTitle) {
+                return computeTitle(value);
+            }
+            if (typeof value === 'object' && value.hasOwnProperty('value')) {
+                return value.value;
+            }
+            return value;
           }).filter(Boolean).join(", ");
         this.rows.push(res);
         return res;

--- a/build.gradle
+++ b/build.gradle
@@ -11,28 +11,3 @@ plugins {
 wrapper {
 	gradleVersion = '8.0.2'
 }
-
-allprojects {
-	tasks.withType(ProcessForkOptions).configureEach {
-		// Prevent Gradle build cache reuse for different _JAVA_OPTIONS
-		inputs.property("ENV:_JAVA_OPTIONS", providers.environmentVariable("_JAVA_OPTIONS")).optional(true)
-	}
-
-	tasks.withType(JavaCompile).configureEach {
-		// Prevent Gradle build cache reuse for different _JAVA_OPTIONS
-		inputs.property("ENV:_JAVA_OPTIONS", providers.environmentVariable("_JAVA_OPTIONS")).optional(true)
-	}
-
-	tasks.withType(Test).configureEach {
-		def language = System.getProperty("user.language") ?: "TR"
-		if (language != null) {
-			systemProperty("user.language", language)
-		}
-		def country = System.getProperty("user.country") ?: "tr"
-		if (country != null) {
-			systemProperty("user.country", country)
-		}
-		// Tests might depend on timezone, so treat it as an input
-		inputs.property("ENV:TZ", providers.environmentVariable("TZ")).optional(true)
-	}
-}

--- a/buildSrc/src/main/groovy/jqwik.common-configuration.gradle
+++ b/buildSrc/src/main/groovy/jqwik.common-configuration.gradle
@@ -66,6 +66,34 @@ tasks.withType(Javadoc) {
 	options.addStringOption('Xdoclint:none', '-quiet')
 }
 
+tasks.withType(ProcessForkOptions).configureEach {
+	// Prevent Gradle build cache reuse for different _JAVA_OPTIONS
+	inputs.property("ENV:_JAVA_OPTIONS", providers.environmentVariable("_JAVA_OPTIONS")).optional(true)
+}
+
+tasks.withType(JavaCompile).configureEach {
+	// Prevent Gradle build cache reuse for different _JAVA_OPTIONS
+	inputs.property("ENV:_JAVA_OPTIONS", providers.environmentVariable("_JAVA_OPTIONS")).optional(true)
+}
+
+tasks.withType(Test).configureEach {
+	def language = System.getProperty("user.language") ?: "TR"
+	if (language != null) {
+		systemProperty("user.language", language)
+	}
+	def country = System.getProperty("user.country") ?: "tr"
+	if (country != null) {
+		systemProperty("user.country", country)
+	}
+	// Tests might depend on timezone, so treat it as an input
+	inputs.property("ENV:TZ", providers.environmentVariable("TZ")).optional(true)
+
+	def testExtraJvmArgs = project.findProperty("testExtraJvmArgs")
+	if (testExtraJvmArgs instanceof String && !testExtraJvmArgs.isEmpty()) {
+		jvmArgs(testExtraJvmArgs.split(" ::: "))
+	}
+}
+
 // Enable to get more compiler warnings.
 //	tasks.withType(JavaCompile) {
 //		options.compilerArgs << '-Xlint:unchecked'


### PR DESCRIPTION
## Overview

Semeru uses [Open9J](https://github.com/eclipse-openj9/openj9) JIT, so it might behave differently from the other OpenJDK distributions, so it is assigned a greater weight in the test matrix.

The option for testing with "same hashcode" -XX:hashCode=2 is moved to Test task execution only since javac, and kotlinc do not behave well with "same hashcode".

Semeru does not support "same hashcode" option yet, and I raised https://github.com/eclipse-openj9/openj9/issues/17309 to track that.

See https://www.ibm.com/support/pages/semeru-runtimes-getting-started

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
