### PR TITLE
perf: make anyForSubtypeOf cacheable

### DIFF
--- a/api/src/main/java/net/jqwik/api/Arbitrary.java
+++ b/api/src/main/java/net/jqwik/api/Arbitrary.java
@@ -1,5 +1,6 @@
 package net.jqwik.api;
 
+import java.io.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;

--- a/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultTypeArbitrary.java
+++ b/engine/src/main/java/net/jqwik/engine/properties/arbitraries/DefaultTypeArbitrary.java
@@ -4,6 +4,8 @@ import java.lang.reflect.*;
 import java.util.*;
 import java.util.function.*;
 
+import net.jqwik.api.support.*;
+
 import org.jspecify.annotations.*;
 import org.junit.platform.commons.support.*;
 
@@ -34,6 +36,25 @@ public class DefaultTypeArbitrary<T extends @Nullable Object> extends ArbitraryD
 	@Override
 	protected Arbitrary<T> arbitrary() {
 		return traverseArbitrary;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == null || getClass() != o.getClass()) return false;
+		DefaultTypeArbitrary<?> that = (DefaultTypeArbitrary<?>) o;
+		return defaultsSet == that.defaultsSet &&
+				   Objects.equals(targetType, that.targetType) &&
+				   Objects.equals(explicitCreators, that.explicitCreators) &&
+				   Objects.equals(constructorFilters, that.constructorFilters) &&
+				   Objects.equals(factoryMethodFilters, that.factoryMethodFilters);
+		// TODO: compare traverseArbitrary.enableRecursion as well.
+		//   NOTE: we can't call Objects.equals(traverseArbitrary, ..) since it results in StackOverflowError due to
+		//     traverseArbitrary -> traverser -> DefaultTypeArbitrary cycle since TypeTraverser is an inner class so it brings the loop
+	}
+
+	@Override
+	public int hashCode() {
+		return HashCodeSupport.hash(targetType, explicitCreators, constructorFilters, factoryMethodFilters, defaultsSet);
 	}
 
 	private DefaultTypeArbitrary<T> cloneWithoutDefaultsSet() {

--- a/kotlin/src/main/kotlin/net/jqwik/kotlin/api/AnyForSubtypeOfDsl.kt
+++ b/kotlin/src/main/kotlin/net/jqwik/kotlin/api/AnyForSubtypeOfDsl.kt
@@ -37,4 +37,17 @@ class SubtypeScope<T: Any> {
         val targetType: KClass<out T>,
         val arbitraryFactory: () -> Arbitrary<out T>
     )
+
+    override fun hashCode(): Int {
+        return customProviders.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SubtypeScope<*>
+
+        return customProviders == other.customProviders
+    }
 }

--- a/kotlin/src/test/kotlin/net/jqwik/kotlin/AnyForSubtypeOfTests.kt
+++ b/kotlin/src/test/kotlin/net/jqwik/kotlin/AnyForSubtypeOfTests.kt
@@ -10,7 +10,8 @@ import java.util.*
 class AnyForSubtypeOfTests {
 
     sealed interface Interface
-    class Implementation(val value: String) : Interface
+    // Make generator Arbitrary<Implementation> cacheable by ensuring Implementation has equals/hashCode
+    data class Implementation(val value: String) : Interface
 
     @Example
     fun `anyForSubtypeOf() returns type arbitrary for any implementations of given sealed interface`(@ForAll random: Random) {


### PR DESCRIPTION
## Overview

This is a prototype that might resolve https://github.com/jqwik-team/jqwik/issues/624

### Details

It turns out kotlinc inserts "sam wrappers" when converting Kotlin lambdas into Java functional interfaces. The sam wrappers do not have equals/hashCode, so it defeats jqwik's caching.

The fix is to move out `.flatMap { ... }` out of `inline` function, so kotlinc no longer adds [`sam wrappers`](https://github.com/JetBrains/kotlin/blob/54fa2d938aee9fc428ffd9b00ef2791cef3ec430/compiler/ir/backend.common/src/org/jetbrains/kotlin/backend/common/lower/SingleAbstractMethodLowering.kt#L159).

TODO:
- [ ] `DefaultTypeArbitrary.equals` should account for `traverseArbitrary.enableRecursion` somehow
- [ ] `net.jqwik.kotlin.api.SubtypeScope#hashCode` does not seem to trigger when executing `AnyForSubtypeOfTests`. I guess it should somehow
- [ ] I haven't actually compared the performance for `anyForSubtypeOf`

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jqwik-team/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
